### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 
 https://github.com/user-attachments/assets/8a40565a-fcdd-47bf-ae67-bc870611c908
 
+[![cesium-mcp MCP server](https://glama.ai/mcp/servers/gaopengbin/cesium-mcp/badges/card.svg)](https://glama.ai/mcp/servers/gaopengbin/cesium-mcp)
+
 ## Packages
 
 | Package | Description | npm |


### PR DESCRIPTION
This PR adds a badge for the [cesium-mcp](https://glama.ai/mcp/servers/gaopengbin/cesium-mcp) server listing in Glama MCP server directory.

[![cesium-mcp MCP server](https://glama.ai/mcp/servers/gaopengbin/cesium-mcp/badges/card.svg)](https://glama.ai/mcp/servers/gaopengbin/cesium-mcp)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.