### PR TITLE
docs: document MCP v2 preview release

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ https://github.com/user-attachments/assets/8a40565a-fcdd-47bf-ae67-bc870611c908
 | **cesium-mcp-webmcp** | Native `document.modelContext` adapter for Cesium tool contracts | New browser adapter | [source](packages/cesium-mcp-webmcp/) |
 | **examples/webmcp-integration** | Focused npm + Vite integration without a chat UI or MCP server | Developer example | [example](examples/webmcp-integration/) |
 | **examples/browser-agent** | Browser-only AI agent with automatic WebMCP exposure | Recommended | [example](examples/browser-agent/) · [live demo](https://cesium-browser-agent.pages.dev/) |
-| **cesium-mcp-runtime** | MCP server (stdio + HTTP) | Stable, slow updates | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime) · [source](packages/cesium-mcp-runtime/) |
+| **cesium-mcp-runtime** | MCP server (stdio + HTTP) | Stable + MCP v2 preview | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime) · [source](packages/cesium-mcp-runtime/) |
 | **cesium-mcp-dev** | CesiumJS API knowledge base for coding assistants | Maintained | [![npm](https://img.shields.io/npm/v/cesium-mcp-dev)](https://www.npmjs.com/package/cesium-mcp-dev) · [source](packages/cesium-mcp-dev/) |
 
 > **Which one?** Personal project or quick try → browser-agent. Let a compatible browser agent discover page-local Cesium tools → WebMCP. Existing web app embedding an AI assistant → bridge + your own function calling. Calling from Claude Desktop / Cursor / Dify → MCP runtime.
@@ -148,12 +148,23 @@ See [examples/browser-agent/index.html](examples/browser-agent/index.html) for a
 Install bridge as in Path 2, then start the MCP runtime:
 
 ```bash
-# stdio mode (Claude Desktop, VS Code, Cursor)
+# Stable channel — npm latest (1.143.3)
 npx cesium-mcp-runtime
 
-# HTTP mode (Dify, remote/cloud MCP clients)
+# MCP v2 preview — npm next (1.143.4-next.0)
+npx cesium-mcp-runtime@next
+
+# HTTP mode; add @next to use the preview
 npx cesium-mcp-runtime --transport http --port 3000
+npx cesium-mcp-runtime@next --transport http --port 3000
 ```
+
+The `next` preview serves existing MCP `2025-11-25` clients and the new
+`2026-07-28` protocol from the same stdio/HTTP entry. It uses the stable
+TypeScript SDK v2 and has passed the official `server-stateless` conformance
+scenario (28/28). The npm `latest` tag remains on `1.143.3`, so you can switch
+back by removing `@next`. For matching preview package versions, install
+`cesium-mcp-bridge@next` in the browser application.
 
 MCP client config:
 
@@ -167,6 +178,9 @@ MCP client config:
   }
 }
 ```
+
+To test the preview from an MCP client, change the last argument to
+`"cesium-mcp-runtime@next"`.
 
 ## 62 Available Command Tools
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ https://github.com/user-attachments/assets/8a40565a-fcdd-47bf-ae67-bc870611c908
 | **cesium-mcp-webmcp** | 基于原生 `document.modelContext` 的 Cesium 工具适配层 | 新增浏览器适配层 | [源码](packages/cesium-mcp-webmcp/) |
 | **examples/webmcp-integration** | 不包含聊天 UI 和 MCP 服务的 npm + Vite 接入示例 | 开发者示例 | [示例](examples/webmcp-integration/) |
 | **examples/browser-agent** | 纯浏览器 AI Agent，自动暴露 WebMCP 工具 | 推荐入口 | [示例](examples/browser-agent/) · [在线 demo](https://cesium-browser-agent.pages.dev/) |
-| **cesium-mcp-runtime** | MCP 服务器（stdio + HTTP） | 稳定，按需更新 | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime) · [源码](packages/cesium-mcp-runtime/) |
+| **cesium-mcp-runtime** | MCP 服务器（stdio + HTTP） | 稳定版 + MCP v2 预览版 | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime) · [源码](packages/cesium-mcp-runtime/) |
 | **cesium-mcp-dev** | 给代码助手用的 CesiumJS API 知识库 | 维护中 | [![npm](https://img.shields.io/npm/v/cesium-mcp-dev)](https://www.npmjs.com/package/cesium-mcp-dev) · [源码](packages/cesium-mcp-dev/) |
 
 > **怎么选？** 个人项目或想最快试用 → browser-agent；让兼容浏览器的 Agent 发现页面内 Cesium 工具 → WebMCP；已有 Web 应用要嵌 AI 助手 → bridge + 自己接 function calling；要从 Claude Desktop / Cursor / Dify 调用 → MCP runtime。
@@ -151,12 +151,22 @@ const bridge = new CesiumBridge(viewer);
 按路径 2 安装 bridge，然后启动 MCP runtime：
 
 ```bash
-# stdio 模式（Claude Desktop、VS Code、Cursor）
+# 稳定通道 — npm latest（1.143.3）
 npx cesium-mcp-runtime
 
-# HTTP 模式（Dify、远程/云端 MCP 客户端）
+# MCP v2 预览通道 — npm next（1.143.4-next.0）
+npx cesium-mcp-runtime@next
+
+# HTTP 模式；使用预览版时加 @next
 npx cesium-mcp-runtime --transport http --port 3000
+npx cesium-mcp-runtime@next --transport http --port 3000
 ```
+
+`next` 预览版通过同一个 stdio/HTTP 入口同时支持现有 MCP `2025-11-25`
+客户端和新的 `2026-07-28` 协议，使用稳定版 TypeScript SDK v2，并已通过
+官方 `server-stateless` 一致性场景（28/28）。npm `latest` 仍保持在
+`1.143.3`；去掉 `@next` 即可回退。若希望浏览器端包版本一致，请在应用中
+安装 `cesium-mcp-bridge@next`。
 
 MCP 客户端配置：
 
@@ -171,25 +181,28 @@ MCP 客户端配置：
 }
 ```
 
-## 58 个可用工具
+在 MCP 客户端中测试预览版时，把最后一个参数改为
+`"cesium-mcp-runtime@next"`。
 
-工具按 **12 个工具集** 组织。默认启用 4 个核心工具集（约 31 个工具）。设置 `CESIUM_TOOLSETS=all` 启用全部，或由 AI 在运行时动态按需发现和激活。
+## 62 个可用命令工具
 
-> **国际化**: 工具描述默认英文，设置 `CESIUM_LOCALE=zh-CN` 切换中文。
+工具按 **12 个工具集** 组织。默认启用 4 个核心工具集（30 个命令工具）。设置 `CESIUM_TOOLSETS=all` 启用全部，或由 AI 在运行时动态按需发现和激活。
+
+> **单一工具契约**：工具描述默认英文，设置 `CESIUM_LOCALE=zh-CN` 切换中文。标题、行为标注、多语言描述、默认值和 Runtime 输入校验都来自 `cesium-mcp-contracts` 中共享的 JSON Schema。
 
 | 工具集 | 工具 |
 |--------|------|
 | **view** (默认) | `flyTo`, `setView`, `getView`, `zoomToExtent`, `saveViewpoint`, `loadViewpoint`, `listViewpoints`, `exportScene` |
 | **entity** (默认) | `addMarker`, `addLabel`, `addModel`, `addPolygon`, `addPolyline`, `updateEntity`, `removeEntity`, `batchAddEntities`, `queryEntities`, `getEntityProperties` |
-| **layer** (默认) | `addGeoJsonLayer`, `listLayers`, `removeLayer`, `clearAll`, `setLayerVisibility`, `updateLayerStyle`, `getLayerSchema`, `setBasemap` |
+| **layer** (默认) | `addGeoJsonLayer`, `addGeoJsonPrimitive`, `listLayers`, `removeLayer`, `clearAll`, `setLayerVisibility`, `updateLayerStyle`, `getLayerSchema`, `setBasemap` |
 | **interaction** (默认) | `screenshot`, `highlight`, `measure` |
 | camera | `lookAtTransform`, `startOrbit`, `stopOrbit`, `setCameraOptions` |
 | entity-ext | `addBillboard`, `addBox`, `addCorridor`, `addCylinder`, `addEllipse`, `addRectangle`, `addWall` |
 | animation | `createAnimation`, `controlAnimation`, `removeAnimation`, `listAnimations`, `updateAnimationPath`, `trackEntity`, `controlClock`, `setGlobeLighting` |
-| tiles | `load3dTiles`, `loadTerrain`, `loadImageryService`, `loadCzml`, `loadKml` |
+| tiles | `load3dTiles`, `load3dGaussianSplat`, `loadTerrain`, `loadImageryService`, `loadCzml`, `loadKml`, `setEdgeDisplayMode` |
 | trajectory | `playTrajectory` |
 | heatmap | `addHeatmap` |
-| scene | `setSceneOptions`, `setPostProcess` |
+| scene | `setSceneOptions`, `setPostProcess`, `setIonToken`（仅 Runtime） |
 | geolocation | `geocode` |
 
 > **与 CesiumGS 官方 MCP 服务器的关系**：`camera`、`entity-ext` 和 `animation` 工具集原生融合了 [CesiumGS/cesium-mcp-server](https://github.com/CesiumGS/cesium-mcp-server)（Camera Server、Entity Server、Animation Server）的能力到本项目的统一 Bridge 架构中。一个 MCP 服务器即可获得全部官方功能加更多工具，无需运行多个进程。

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -27,6 +27,13 @@ export default defineConfig({
           { text: 'WebMCP', link: '/zh-CN/guide/webmcp' },
           { text: 'API 参考', link: '/zh-CN/api/bridge' },
           { text: '示例', link: '/zh-CN/examples/' },
+          {
+            text: `v${version}`,
+            items: [
+              { text: '更新日志', link: 'https://github.com/gaopengbin/cesium-mcp/releases' },
+              { text: 'npm', link: 'https://www.npmjs.com/package/cesium-mcp-runtime' },
+            ],
+          },
         ],
         sidebar: {
           '/zh-CN/guide/': [

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -4,6 +4,15 @@
 
 [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime)
 
+::: tip Release channels
+- Stable: `npx cesium-mcp-runtime` → `latest@1.143.3`
+- MCP v2 preview: `npx cesium-mcp-runtime@next` → `next@1.143.4-next.0`
+
+The preview supports MCP `2025-11-25` and `2026-07-28`, uses the stable
+TypeScript SDK v2, and passed the official `server-stateless` conformance
+scenario (28/28). Remove `@next` to return to the stable release.
+:::
+
 ## Installation & Run
 
 ```bash

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,6 +10,20 @@ This guide configures the Node.js MCP runtime for desktop clients and workflow p
 
 ## Installation
 
+::: tip MCP 2026-07-28 preview
+`cesium-mcp-runtime@1.143.4-next.0` is available on npm under the `next`
+tag. It supports existing MCP `2025-11-25` clients and the new
+`2026-07-28` protocol from the same stdio/HTTP entry. The stable `latest`
+tag remains on `1.143.3`.
+
+```bash
+npm install cesium-mcp-bridge@next
+npx cesium-mcp-runtime@next
+```
+
+Remove `@next` to return to the stable channel.
+:::
+
 ### 1. Add the Bridge to Your CesiumJS App
 
 ```bash
@@ -42,6 +56,13 @@ npx cesium-mcp-runtime --transport http --port 3211
 This starts a Node.js process that:
 - Exposes MCP tools on the selected transport (stdio or HTTP)
 - Opens a **WebSocket server** on port 9100 (for the browser bridge)
+
+To run the MCP v2 preview in either mode, append `@next` to the package name:
+
+```bash
+npx cesium-mcp-runtime@next
+npx cesium-mcp-runtime@next --transport http --port 3211
+```
 
 ### 3. Configure Your AI Agent
 
@@ -89,6 +110,9 @@ Create `.cursor/mcp.json`:
   }
 }
 ```
+
+For the preview channel, use `"cesium-mcp-runtime@next"` as the last
+argument in any of the client configurations above.
 
 #### Dify / n8n (HTTP transport)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ features:
   - icon:
       src: /icons/clients.svg
     title: WebMCP and MCP
-    details: Expose page-local tools directly to compatible browsers, or connect Claude Desktop, VS Code, Cursor, Dify, and other MCP clients through the runtime.
+    details: Expose page-local tools directly to compatible browsers, or connect MCP clients through the runtime. The v2 preview supports both MCP 2025-11-25 and 2026-07-28.
   - icon:
       src: /icons/packages.svg
     title: Composable Packages, One Ecosystem

--- a/docs/mcp-2026-07-28-upgrade-plan.md
+++ b/docs/mcp-2026-07-28-upgrade-plan.md
@@ -1,6 +1,6 @@
 # MCP 2026-07-28 升级计划
 
-> 状态：SDK v2 stable 已接入，官方 `server-stateless` 一致性场景已通过
+> 状态：SDK v2 stable 已接入，`1.143.4-next.0` 已发布到 npm `next`
 > 工作分支：`codex/mcp-2026-07-28-upgrade`
 > 基线：`@modelcontextprotocol/sdk ^1.29.0`、MCP `2025-11-25` 兼容行为
 
@@ -20,12 +20,14 @@
 - 精确锁定官方 conformance `0.2.0-alpha.10`，`server-stateless`
   场景达到 28/28 通过、0 失败；2 个 list-changed SHOULD 项保留为 warning。
 - 将一致性测试专用诊断工具限制在 `CESIUM_MCP_CONFORMANCE=1`，不混入生产工具列表。
+- 已合并到 `main`，并通过 GitHub Actions 将 bridge、runtime、dev
+  `1.143.4-next.0` 发布到 npm `next`；`latest` 保持 `1.143.3`。
+- 已更新根 README、runtime README 和官网中英文安装/兼容性文档。
 
 正式版发布前剩余：
 
-- 更新面向用户的中英文 runtime 文档和 changeset。
 - 完成真实 Chrome → MCP HTTP → WebSocket → Cesium 的浏览器闭环验证。
-- 先发布 npm `next` 验证，不移动 `latest`。
+- 收集 npm `next` 的真实客户端验证结果，确认无阻断问题后再移动 `latest`。
 
 ## 1. 目标
 

--- a/docs/zh-CN/api/runtime.md
+++ b/docs/zh-CN/api/runtime.md
@@ -4,6 +4,15 @@
 
 [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime)
 
+::: tip 发布通道
+- 稳定版：`npx cesium-mcp-runtime` → `latest@1.143.3`
+- MCP v2 预览版：`npx cesium-mcp-runtime@next` → `next@1.143.4-next.0`
+
+预览版同时支持 MCP `2025-11-25` 和 `2026-07-28`，使用稳定版 TypeScript
+SDK v2，并已通过官方 `server-stateless` 一致性场景（28/28）。去掉
+`@next` 即可回到稳定版。
+:::
+
 ## 安装与运行
 
 ```bash

--- a/docs/zh-CN/guide/getting-started.md
+++ b/docs/zh-CN/guide/getting-started.md
@@ -10,6 +10,19 @@
 
 ## 安装
 
+::: tip MCP 2026-07-28 预览版
+`cesium-mcp-runtime@1.143.4-next.0` 已通过 npm `next` 标签发布。它从同一个
+stdio/HTTP 入口同时支持现有 MCP `2025-11-25` 客户端和新的 `2026-07-28`
+协议。稳定版 `latest` 仍保持在 `1.143.3`。
+
+```bash
+npm install cesium-mcp-bridge@next
+npx cesium-mcp-runtime@next
+```
+
+去掉 `@next` 即可回到稳定通道。
+:::
+
 ### 1. 在 CesiumJS 应用中添加 Bridge
 
 ```bash
@@ -42,6 +55,13 @@ npx cesium-mcp-runtime --transport http --port 3211
 运行后会启动一个 Node.js 进程，它会：
 - 在所选传输方式（stdio 或 HTTP）上提供 MCP 工具
 - 在 9100 端口开启 **WebSocket 服务器**（与浏览器 Bridge 通信）
+
+要在任一模式下运行 MCP v2 预览版，请在包名后加 `@next`：
+
+```bash
+npx cesium-mcp-runtime@next
+npx cesium-mcp-runtime@next --transport http --port 3211
+```
 
 ### 3. 配置 AI 智能体
 
@@ -89,6 +109,9 @@ npx cesium-mcp-runtime --transport http --port 3211
   }
 }
 ```
+
+在上述任一客户端配置中测试预览版时，将最后一个参数改为
+`"cesium-mcp-runtime@next"`。
 
 #### Dify / n8n（HTTP 传输模式）
 

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -24,7 +24,7 @@ features:
   - icon:
       src: /icons/clients.svg
     title: 同时支持 WebMCP 与 MCP
-    details: 可直接向兼容浏览器暴露页面工具，也可通过 Runtime 连接 Claude Desktop、VS Code、Cursor、Dify 等 MCP 客户端。
+    details: 可直接向兼容浏览器暴露页面工具，也可通过 Runtime 连接 MCP 客户端。v2 预览版同时支持 MCP 2025-11-25 与 2026-07-28。
   - icon:
       src: /icons/packages.svg
     title: 可组合的包，一个生态

--- a/packages/cesium-mcp-runtime/README.md
+++ b/packages/cesium-mcp-runtime/README.md
@@ -7,7 +7,12 @@
 [![npm version](https://img.shields.io/npm/v/cesium-mcp-runtime.svg)](https://www.npmjs.com/package/cesium-mcp-runtime)
 [![license](https://img.shields.io/npm/l/cesium-mcp-runtime.svg)](LICENSE)
 
-> **Status**: stable, slow release cadence (updated as needed). If you only want to try the "AI + Cesium" feel, [examples/browser-agent](../../examples/browser-agent/) is the recommended starting point — zero backend, runs in three minutes. See [Which mode should I use?](https://gaopengbin.github.io/cesium-mcp/guide/which-mode.html)
+> **Release channels**: `latest` is the stable `1.143.3` line. `next` is
+> `1.143.4-next.0`, the MCP SDK v2 preview with MCP `2026-07-28` support.
+> If you only want to try the "AI + Cesium" feel,
+> [examples/browser-agent](../../examples/browser-agent/) is the recommended
+> starting point — zero backend, runs in three minutes. See
+> [Which mode should I use?](https://gaopengbin.github.io/cesium-mcp/guide/which-mode.html).
 
 ## Architecture
 
@@ -28,11 +33,15 @@ Two transport modes are supported:
 ## Install & Run
 
 ```bash
-# Run directly with npx (stdio mode, default)
+# Stable channel (stdio mode, default)
 npx cesium-mcp-runtime
 
-# Or install globally
+# MCP v2 preview
+npx cesium-mcp-runtime@next
+
+# Or install either channel globally
 npm install -g cesium-mcp-runtime
+npm install -g cesium-mcp-runtime@next
 cesium-mcp-runtime
 ```
 
@@ -324,14 +333,15 @@ curl -X POST http://localhost:9100/push \
 
 ## Compatibility
 
-| cesium-mcp-runtime | cesium-mcp-bridge | Cesium |
-|--------------------|-------------------|--------|
-| 1.143.x | 1.143.x | ~1.143.0 |
+| Channel | Runtime | Bridge | MCP protocol | Cesium |
+|---------|---------|--------|--------------|--------|
+| `latest` | `1.143.3` | `1.143.3` | 2025-era clients | `~1.143.0` |
+| `next` | `1.143.4-next.0` | `1.143.4-next.0` | `2025-11-25` + `2026-07-28` | `~1.143.0` |
 
-The SDK v2 upgrade branch serves MCP `2025-11-25` clients and the
-`2026-07-28` protocol from the same stdio/HTTP entry using the stable
-`@modelcontextprotocol/server` and `@modelcontextprotocol/node` `2.0.0`
-packages.
+The `next` release serves both protocol generations from the same stdio/HTTP
+entry using stable `@modelcontextprotocol/server` and
+`@modelcontextprotocol/node` `2.0.0` packages. Remove `@next` from the npx or
+npm command to return to `latest`.
 
 The repository pins the official conformance runner separately and validates
 the `2026-07-28` `server-stateless` scenario with:

--- a/packages/cesium-mcp-runtime/README.zh-CN.md
+++ b/packages/cesium-mcp-runtime/README.zh-CN.md
@@ -7,7 +7,11 @@
 [![npm version](https://img.shields.io/npm/v/cesium-mcp-runtime.svg)](https://www.npmjs.com/package/cesium-mcp-runtime)
 [![license](https://img.shields.io/npm/l/cesium-mcp-runtime.svg)](LICENSE)
 
-> **状态说明**：release 节奏偏慢（按需更新）。如果你只是想试 "AI + Cesium" 的效果，[examples/browser-agent](../../examples/browser-agent/) 是更推荐的起点（零后端、三分钟上手）。详见 [我应该用哪种模式？](https://gaopengbin.github.io/cesium-mcp/zh-CN/guide/which-mode.html)
+> **发布通道**：`latest` 是稳定版 `1.143.3`；`next` 是
+> `1.143.4-next.0`，提供 MCP `2026-07-28` 支持的 SDK v2 预览版。
+> 如果你只是想体验 “AI + Cesium”，更推荐从
+> [examples/browser-agent](../../examples/browser-agent/) 开始（零后端、三分钟上手）。
+> 详见 [我应该用哪种模式？](https://gaopengbin.github.io/cesium-mcp/zh-CN/guide/which-mode.html)。
 
 ## 架构
 
@@ -28,11 +32,15 @@ AI 智能体 <--MCP HTTP---> cesium-mcp-runtime <--WebSocket--> 浏览器 (cesiu
 ## 安装与运行
 
 ```bash
-# 使用 npx 直接运行（stdio 模式，默认）
+# 稳定通道（stdio 模式，默认）
 npx cesium-mcp-runtime
 
-# 或全局安装
+# MCP v2 预览通道
+npx cesium-mcp-runtime@next
+
+# 也可以全局安装任一通道
 npm install -g cesium-mcp-runtime
+npm install -g cesium-mcp-runtime@next
 cesium-mcp-runtime
 ```
 
@@ -324,13 +332,14 @@ curl -X POST http://localhost:9100/push \
 
 ## 兼容性
 
-| cesium-mcp-runtime | cesium-mcp-bridge | Cesium |
-|--------------------|-------------------|--------|
-| 1.143.x | 1.143.x | ~1.143.0 |
+| 通道 | Runtime | Bridge | MCP 协议 | Cesium |
+|------|---------|--------|----------|--------|
+| `latest` | `1.143.3` | `1.143.3` | 2025-era 客户端 | `~1.143.0` |
+| `next` | `1.143.4-next.0` | `1.143.4-next.0` | `2025-11-25` + `2026-07-28` | `~1.143.0` |
 
-SDK v2 升级分支通过同一个 stdio/HTTP 入口同时支持 MCP `2025-11-25`
-客户端和 `2026-07-28` 协议，并使用稳定版
+`next` 通过同一个 stdio/HTTP 入口服务两代协议，使用稳定版
 `@modelcontextprotocol/server`、`@modelcontextprotocol/node` `2.0.0`。
+从 npx 或 npm 命令中去掉 `@next` 即可回到 `latest`。
 
 仓库单独精确锁定官方 conformance runner，并通过以下命令验证
 `2026-07-28` 的 `server-stateless` 场景：


### PR DESCRIPTION
## Summary

- document `latest@1.143.3` and `next@1.143.4-next.0` across the English and Chinese READMEs
- add MCP `2025-11-25` / `2026-07-28` compatibility, install, preview, and rollback guidance
- update the VitePress homepage, getting-started guide, Runtime API, and upgrade status
- show the runtime version menu in the Chinese documentation navigation
- correct the stale Chinese Runtime tool count and toolset inventory

## Why

The MCP SDK v2 prerelease is now published on npm under the `next` tag, but the user-facing documentation still pointed only to `latest` and described the implementation as an upgrade branch. Users need an explicit, reversible path for trying the preview without moving the stable npm tag.

## User impact

Users can run `npx cesium-mcp-runtime@next`, understand which MCP protocol revisions it supports, install a matching Bridge preview, and return to stable by removing `@next`.

## Validation

- `npm run docs:build`
- verified generated English and Chinese HTML contains `v1.143.4-next.0`, the `@next` commands, and the bilingual protocol notice
- `git diff --check`