### PR TITLE
fix(runtime): serve viewer URLs with query parameters

### DIFF
--- a/.changeset/viewer-session-query.md
+++ b/.changeset/viewer-session-query.md
@@ -1,0 +1,6 @@
+---
+"cesium-mcp-runtime": patch
+---
+
+Serve the built-in Cesium Viewer when `session` or other query parameters are
+present on `/` or `/index.html`.

--- a/docs/mcp-2026-07-28-upgrade-plan.md
+++ b/docs/mcp-2026-07-28-upgrade-plan.md
@@ -26,8 +26,12 @@
 
 正式版发布前剩余：
 
-- 完成真实 Chrome → MCP HTTP → WebSocket → Cesium 的浏览器闭环验证。
-- 收集 npm `next` 的真实客户端验证结果，确认无阻断问题后再移动 `latest`。
+- 已完成 npm `next` 的真实 Chrome → MCP HTTP → WebSocket → Cesium 闭环：
+  官方 SDK v2 Client 以 `2026-07-28` modern 模式执行
+  `getView → flyTo → getView`，Chrome Viewer 实际从上海飞到东京。
+- 闭环测试发现内置 Viewer 的 `/?session=...` 被错误返回 404；修复已增加
+  回归测试，需要先发布新的 npm `next` 预发布版本并复测。
+- 新预发布版本确认无阻断问题后，再移动 `latest`。
 
 ## 1. 目标
 

--- a/packages/cesium-mcp-runtime/dist/chunk-H2GV6H7J.js
+++ b/packages/cesium-mcp-runtime/dist/chunk-H2GV6H7J.js
@@ -173,6 +173,11 @@ async function _invokeServerSideTool(action, params) {
   }
   return mcpResult;
 }
+function isViewerRequest(method, url) {
+  if (method !== "GET") return false;
+  const path = new URL(url ?? "/", "http://localhost").pathname;
+  return path === "/" || path === "/index.html";
+}
 async function handleHttpRequest(req, res) {
   const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
   if (requestPath === "/mcp") {
@@ -304,7 +309,7 @@ async function handleHttpRequest(req, res) {
     res.end("// local bridge bundle not found");
     return;
   }
-  if (req.method === "GET" && (req.url === "/" || req.url === "/index.html")) {
+  if (isViewerRequest(req.method, req.url)) {
     const token = process.env.CESIUM_ION_TOKEN || "";
     const html = _getViewerHtml(token, WS_PORT);
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
@@ -2028,6 +2033,7 @@ function _parseArg(argv, key) {
 }
 
 export {
+  isViewerRequest,
   buildMcpServer,
   createCesiumMcpHttpHandler,
   createSandboxServer,

--- a/packages/cesium-mcp-runtime/dist/cli.js
+++ b/packages/cesium-mcp-runtime/dist/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import {
   main
-} from "./chunk-KTW4H6BP.js";
+} from "./chunk-H2GV6H7J.js";
 
 // src/cli.ts
 main(process.argv.slice(2)).catch((err) => {

--- a/packages/cesium-mcp-runtime/dist/index.d.ts
+++ b/packages/cesium-mcp-runtime/dist/index.d.ts
@@ -1,5 +1,6 @@
 import { McpServer, McpHttpHandler } from '@modelcontextprotocol/server';
 
+declare function isViewerRequest(method: string | undefined, url: string | undefined): boolean;
 interface BuildMcpServerOptions {
     toolsets?: Iterable<string>;
     dynamicDiscovery?: boolean;
@@ -17,4 +18,4 @@ declare function createCesiumMcpHttpHandler(): McpHttpHandler;
 declare function createSandboxServer(): McpServer;
 declare function main(argv?: string[]): Promise<void>;
 
-export { type BuildMcpServerOptions, buildMcpServer, createCesiumMcpHttpHandler, createSandboxServer, main };
+export { type BuildMcpServerOptions, buildMcpServer, createCesiumMcpHttpHandler, createSandboxServer, isViewerRequest, main };

--- a/packages/cesium-mcp-runtime/dist/index.js
+++ b/packages/cesium-mcp-runtime/dist/index.js
@@ -2,11 +2,13 @@ import {
   buildMcpServer,
   createCesiumMcpHttpHandler,
   createSandboxServer,
+  isViewerRequest,
   main
-} from "./chunk-KTW4H6BP.js";
+} from "./chunk-H2GV6H7J.js";
 export {
   buildMcpServer,
   createCesiumMcpHttpHandler,
   createSandboxServer,
+  isViewerRequest,
   main
 };

--- a/packages/cesium-mcp-runtime/src/index.test.ts
+++ b/packages/cesium-mcp-runtime/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
+import { isViewerRequest } from './index.js'
 
 /**
  * runtime 的核心逻辑都是模块内函数（依赖模块级 Map 状态），
@@ -73,6 +74,13 @@ describe('HTTP route matching logic', () => {
 
   it('should return not-found for unknown routes', () => {
     expect(routeRequest('GET', '/api/unknown')).toBe('not-found')
+  })
+
+  it('should serve the viewer when session query parameters are present', () => {
+    expect(isViewerRequest('GET', '/?session=e2e-next')).toBe(true)
+    expect(isViewerRequest('GET', '/index.html?session=demo')).toBe(true)
+    expect(isViewerRequest('GET', '/api/status?session=demo')).toBe(false)
+    expect(isViewerRequest('POST', '/?session=demo')).toBe(false)
   })
 })
 

--- a/packages/cesium-mcp-runtime/src/index.ts
+++ b/packages/cesium-mcp-runtime/src/index.ts
@@ -168,6 +168,12 @@ async function _invokeServerSideTool(action: string, params: Record<string, unkn
   return mcpResult
 }
 
+export function isViewerRequest(method: string | undefined, url: string | undefined): boolean {
+  if (method !== 'GET') return false
+  const path = new URL(url ?? '/', 'http://localhost').pathname
+  return path === '/' || path === '/index.html'
+}
+
 /** HTTP 请求处理：POST /api/command */
 async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   const requestPath = new URL(req.url ?? '/', 'http://localhost').pathname
@@ -321,7 +327,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   }
 
   // GET / — serve built-in viewer page
-  if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
+  if (isViewerRequest(req.method, req.url)) {
     const token = process.env.CESIUM_ION_TOKEN || ''
     const html = _getViewerHtml(token, WS_PORT)
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })


### PR DESCRIPTION
## What changed

- route built-in Viewer requests by parsed pathname
- support `/?session=...` and `/index.html?session=...`
- add a focused regression test and patch changeset
- record the real npm `next` Chrome E2E result in the upgrade plan

## Why

The published `1.143.4-next.0` Viewer reads the browser session from the query string, but its HTTP route matched the complete `req.url` exactly. Any documented `?session=` URL therefore returned `404 Not Found` before the Viewer could connect.

## Validation

- real Chrome + `cesium-mcp-runtime@1.143.4-next.0` + `cesium-mcp-bridge@1.143.4-next.0`
- official SDK v2 Client pinned to MCP `2026-07-28`
- `getView → flyTo → getView` changed the live Viewer from Shanghai to Tokyo
- both query-string Viewer routes return HTTP 200 after the fix
- 19 test files / 277 tests passed
- typecheck, ESLint, full build, docs build, and `git diff --check` passed