### PR TITLE
chore: exit MCP v2 prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "cesium-webmcp-integration-example": "0.1.1",


### PR DESCRIPTION
## What changed

Exit Changesets prerelease mode after the `1.143.4-next.1` validation completed successfully.

## Release intent

After this PR merges, the Changesets workflow will prepare stable `1.143.4` package versions. Merging that generated version PR will publish the stable packages to npm and move `latest` from `1.143.3` to `1.143.4`.

## Validation completed before exit

- 19 test files / 277 tests
- TypeScript, ESLint, full build, and docs build
- official SDK v2 Client pinned to MCP `2026-07-28`
- fresh npm install of Runtime and Bridge `1.143.4-next.1`
- real Chrome `getView → flyTo → getView` E2E
- Viewer query routes and bundled Bridge verification