### PR TITLE
docs: record MCP v2 stable release

### DIFF
--- a/docs/mcp-2026-07-28-upgrade-plan.md
+++ b/docs/mcp-2026-07-28-upgrade-plan.md
@@ -1,6 +1,6 @@
 # MCP 2026-07-28 升级计划
 
-> 状态：SDK v2 stable 已接入，`1.143.4-next.1` 已发布并通过 npm 安装闭环复测
+> 状态：升级完成，bridge、runtime、dev `1.143.4` 已发布到 npm `latest`
 > 工作分支：`codex/mcp-2026-07-28-upgrade`
 > 基线：`@modelcontextprotocol/sdk ^1.29.0`、MCP `2025-11-25` 兼容行为
 
@@ -21,10 +21,10 @@
   场景达到 28/28 通过、0 失败；2 个 list-changed SHOULD 项保留为 warning。
 - 将一致性测试专用诊断工具限制在 `CESIUM_MCP_CONFORMANCE=1`，不混入生产工具列表。
 - 已合并到 `main`，并通过 GitHub Actions 将 bridge、runtime、dev
-  `1.143.4-next.1` 发布到 npm `next`；`latest` 保持 `1.143.3`。
+  `1.143.4` 发布到 npm `latest`；`next` 保留 `1.143.4-next.1`。
 - 已更新根 README、runtime README 和官网中英文安装/兼容性文档。
 
-预发布验证已完成：
+发布验证已完成：
 
 - npm 全新安装的 `next.1` 已完成真实 Chrome → MCP HTTP → WebSocket → Cesium
   闭环：
@@ -32,10 +32,10 @@
   `getView → flyTo → getView`，Chrome Viewer 实际飞到悉尼。
 - 内置 Viewer 的 `/?session=...` 和 `/index.html?session=...` 均返回 200。
 - Runtime `/bridge.js` 与 npm 安装的 `bridge@next` 浏览器包完全一致。
-
-正式版发布前剩余：
-
-- 确认将 `1.143.4` 移动到 npm `latest` 的发布时间。
+- 从空目录安装三个 `latest` 包，版本均为 `1.143.4`；官方 SDK v2 Client
+  固定 `2026-07-28` 后发现 63 个工具，Runtime 报告版本 `1.143.4`。
+- 正式版内置 Viewer query 路由返回 200，`/bridge.js` 与安装的
+  `cesium-mcp-bridge` 浏览器 bundle SHA-256 一致。
 
 ## 1. 目标
 


### PR DESCRIPTION
## What changed

- mark the MCP v2 upgrade as complete
- record the `1.143.4` npm `latest` publication for bridge, runtime, and dev
- document the fresh-install post-release verification and modern `2026-07-28` protocol smoke test

## Why

The upgrade plan still described `1.143.4-next.1` as the latest milestone and listed the stable release as pending, although `1.143.4` has now been published and verified.

## Validation

- `npm run docs:build`
- fresh install of all three `@latest` packages
- Runtime query routes returned HTTP 200
- `/bridge.js` matched the installed browser bundle SHA-256
- official MCP v2 client discovered 63 tools using protocol `2026-07-28`