### PR TITLE
fix(dev): repair published CLI entry

### DIFF
--- a/.changeset/quiet-dodos-fix.md
+++ b/.changeset/quiet-dodos-fix.md
@@ -1,0 +1,5 @@
+---
+'cesium-mcp-dev': patch
+---
+
+Fix the published CLI entry so Node can execute the bundle and negotiate both modern and legacy MCP over stdio.

--- a/packages/cesium-mcp-dev/src/mcp-stdio-v2.test.ts
+++ b/packages/cesium-mcp-dev/src/mcp-stdio-v2.test.ts
@@ -1,16 +1,42 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import { Client } from '@modelcontextprotocol/client'
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 const tsxCli = fileURLToPath(import.meta.resolve('tsx/cli'))
 const serverEntry = fileURLToPath(new URL('./stdio-test-server.ts', import.meta.url))
+const bundledServerEntry = fileURLToPath(new URL('../dist/index.js', import.meta.url))
+
+beforeAll(() => {
+  if (!existsSync(bundledServerEntry)) {
+    execFileSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', [
+      'run',
+      'build',
+      '-w',
+      'packages/cesium-mcp-dev',
+    ], {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+    })
+  }
+})
 
 function createTransport(): StdioClientTransport {
   return new StdioClientTransport({
     command: process.execPath,
     args: [tsxCli, serverEntry],
+    cwd: process.cwd(),
+    stderr: 'pipe',
+  })
+}
+
+function createBundledTransport(): StdioClientTransport {
+  return new StdioClientTransport({
+    command: process.execPath,
+    args: [bundledServerEntry],
     cwd: process.cwd(),
     stderr: 'pipe',
   })
@@ -26,6 +52,24 @@ async function expectDevTools(client: Client) {
 }
 
 describe('cesium-mcp-dev MCP SDK v2 stdio entry', () => {
+  it('starts the bundled CLI with a single valid shebang', async () => {
+    const client = new Client({
+      name: 'cesium-mcp-dev-bundle-test',
+      version: '1.0.0',
+    }, {
+      versionNegotiation: {
+        mode: { pin: '2026-07-28' },
+      },
+    })
+    try {
+      await client.connect(createBundledTransport())
+      expect(client.getProtocolEra()).toBe('modern')
+      await expectDevTools(client)
+    } finally {
+      await client.close()
+    }
+  }, 15_000)
+
   it('serves a modern client that pins 2026-07-28', async () => {
     const client = new Client({
       name: 'cesium-mcp-dev-modern-test',

--- a/packages/cesium-mcp-dev/tsup.config.ts
+++ b/packages/cesium-mcp-dev/tsup.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   target: 'node20',
-  banner: { js: '#!/usr/bin/env node' },
   define: {
     __VERSION__: JSON.stringify(pkg.version),
   },


### PR DESCRIPTION
## Summary

- remove the duplicate shebang emitted by the Cesium Dev CLI bundle
- add a bundled-entry protocol regression test
- add a patch changeset for cesium-mcp-dev

## Verification

- npm run build
- npm run typecheck
- npm run lint
- npx vitest run (306 tests)