### PR TITLE
fix: restore self-hosted star history

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,39 @@
+name: Update Star History
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    concurrency:
+      group: star-history
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out chart data branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: star-history-data
+          path: star-history-data
+
+      - name: Generate star history chart
+        uses: nicoloboschi/gh-stars@c659f0480850de4072c66927d0a6c86769f416c5 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          history-path: star-history-data/.github/star-history/data.json
+          svg-path: star-history-data/.github/star-history/chart.svg
+          line-color: '#155EEF'
+
+      - name: Commit updated chart
+        working-directory: star-history-data
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/star-history/data.json .github/star-history/chart.svg
+          git diff --cached --quiet || git commit -m 'chore: update star history'
+          git push

--- a/README.md
+++ b/README.md
@@ -231,13 +231,7 @@ Official CesiumJS releases are reviewed before the compatibility baseline is bum
 
 ## Star History
 
-<a href="https://star-history.com/#gaopengbin/cesium-mcp&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=gaopengbin/cesium-mcp&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=gaopengbin/cesium-mcp&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=gaopengbin/cesium-mcp&type=Date" />
- </picture>
-</a>
+[![Star History Chart](https://raw.githubusercontent.com/gaopengbin/cesium-mcp/star-history-data/.github/star-history/chart.svg)](https://github.com/gaopengbin/cesium-mcp)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -229,13 +229,7 @@ CesiumJS 官方发布新版本后，项目会先核对 Bridge API 和契约行�
 
 ## Star 趋势
 
-<a href="https://star-history.com/#gaopengbin/cesium-mcp&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=gaopengbin/cesium-mcp&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=gaopengbin/cesium-mcp&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=gaopengbin/cesium-mcp&type=Date" />
- </picture>
-</a>
+[![Star History Chart](https://raw.githubusercontent.com/gaopengbin/cesium-mcp/star-history-data/.github/star-history/chart.svg)](https://github.com/gaopengbin/cesium-mcp)
 
 ## 许可证
 


### PR DESCRIPTION
## What changed

- add a daily GitHub Actions workflow that generates a repository-owned star history SVG
- store chart data on the dedicated `star-history-data` branch
- update the English and Chinese README files to embed the generated chart

## Why

GitHub's stargazer API restriction broke public Star History embeds. Generating the chart with the repository's built-in `GITHUB_TOKEN` avoids sharing a PAT with a third party.

## Validation

- only the workflow and README documentation changed
- both Actions dependencies are pinned to exact commit SHAs
- the feature branch is based on the current default branch with no unrelated changes
