### PR TITLE
fix(runtime): ship browser bridge bundle

### DIFF
--- a/.changeset/quiet-pandas-pack.md
+++ b/.changeset/quiet-pandas-pack.md
@@ -1,0 +1,5 @@
+---
+'cesium-mcp-runtime': patch
+---
+
+Ship the browser Bridge bundle inside the Runtime npm package so the built-in Viewer no longer depends on an unpkg fallback. Add a clean-install E2E that packs and installs the public artifacts, opens the real Cesium Viewer, connects its WebSocket bridge, and verifies a camera command round trip.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,11 @@ jobs:
 
       - run: npx vitest run
 
+      - run: npx playwright install --with-deps chromium
+        if: matrix.node-version == 22
+
+      - run: npm run test:e2e:packed
+        if: matrix.node-version == 22
+
       - run: npm run test:conformance:mcp
         if: matrix.node-version == 22

--- a/README.md
+++ b/README.md
@@ -209,9 +209,11 @@ npm install
 npm run build
 npm test
 npm run test:contracts
+npm run test:e2e:packed
 ```
 
 `test:contracts` is the focused parity gate for MCP Runtime metadata, WebMCP registration, Function Calling definitions, and the 60-tool Bridge Executor Registry.
+`test:e2e:packed` builds npm tarballs, installs them in a clean temporary project, opens the real Cesium Viewer, and verifies a Runtime-WebSocket-Bridge command round trip.
 
 ## Version Policy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,7 +209,12 @@ git clone https://github.com/gaopengbin/cesium-mcp.git
 cd cesium-mcp
 npm install
 npm run build
+npm test
+npm run test:contracts
+npm run test:e2e:packed
 ```
+
+`test:e2e:packed` 会生成 npm tarball、安装到全新的临时项目、打开真实 Cesium Viewer，并验证 Runtime、WebSocket 与 Bridge 的命令往返。
 
 ## 版本策略
 

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -76,6 +76,8 @@ cesium-mcp-runtime
 
 Tools are organized into **12 toolsets**. By default, 4 core toolsets are enabled (30 tools). Set `CESIUM_TOOLSETS=all` for everything, or let the AI discover and activate toolsets dynamically. Shared titles, behavior annotations, localized descriptions, defaults, input validation, advertised output schemas, and structured results come from the canonical JSON Schemas in `cesium-mcp-contracts`. Tool calls retain text `content` for older clients.
 
+The Runtime npm artifact includes the browser Bridge bundle served by `/bridge.js`. The built-in Viewer does not depend on an unpkg fallback, while CesiumJS assets continue to load from the official Cesium CDN.
+
 ### Toolsets
 
 | Toolset | Tools | Default | Description |

--- a/docs/zh-CN/api/runtime.md
+++ b/docs/zh-CN/api/runtime.md
@@ -75,6 +75,8 @@ cesium-mcp-runtime
 
 工具按 **12 个工具集** 组织。默认启用 4 个核心工具集（30 个工具）。设置 `CESIUM_TOOLSETS=all` 启用全部，或由 AI 在运行时动态发现和激活。共享标题、行为标注、多语言描述、默认值、输入校验、对外发布的输出 Schema 和结构化结果统一来自 `cesium-mcp-contracts` 中的标准 JSON Schema；旧客户端仍可读取文本 `content`。
 
+Runtime npm 产物会包含由 `/bridge.js` 提供的浏览器 Bridge bundle，内置 Viewer 不再依赖 unpkg 回退；CesiumJS 资源仍从 Cesium 官方 CDN 加载。
+
 ### 工具集
 
 | 工具集 | 工具数 | 默认启用 | 描述 |

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "vitest",
     "test:contracts": "vitest run packages/cesium-mcp-runtime/src/tool-manifest.test.ts packages/cesium-mcp-webmcp/src/index.test.ts packages/cesium-mcp-bridge/src/executors/executor-registry.test.ts examples/browser-agent/contract-parity.test.ts",
+    "test:e2e:packed": "npm run build && node scripts/run-packed-runtime-e2e.mjs",
+    "test:e2e:published": "node scripts/run-packed-runtime-e2e.mjs --runtime cesium-mcp-runtime@latest",
     "test:conformance:mcp": "npm run build -w packages/cesium-mcp-runtime && node scripts/run-mcp-conformance.mjs",
     "lint": "eslint packages/*/src/**/*.ts",
     "clean": "node -e \"const fs=require('node:fs'); for (const dir of fs.globSync('packages/*/dist')) fs.rmSync(dir,{ recursive:true, force:true })\"",

--- a/packages/cesium-mcp-runtime/README.md
+++ b/packages/cesium-mcp-runtime/README.md
@@ -23,6 +23,8 @@ AI Agent <--MCP HTTP---> cesium-mcp-runtime <--WebSocket--> Browser (cesium-mcp-
 
 The runtime acts as a bridge between MCP-compatible AI clients (Claude Desktop, VS Code Copilot, Cursor, etc.) and a browser running CesiumJS. It translates MCP tool calls into WebSocket commands that [cesium-mcp-bridge](https://www.npmjs.com/package/cesium-mcp-bridge) executes.
 
+The npm package ships its browser Bridge bundle locally. The built-in Viewer at `http://localhost:9100/` therefore does not depend on an unpkg fallback; CesiumJS itself is still loaded from the official Cesium CDN.
+
 Two transport modes are supported:
 
 | Transport | Use Case | Protocol |

--- a/packages/cesium-mcp-runtime/README.zh-CN.md
+++ b/packages/cesium-mcp-runtime/README.zh-CN.md
@@ -22,6 +22,8 @@ AI 智能体 <--MCP HTTP---> cesium-mcp-runtime <--WebSocket--> 浏览器 (cesiu
 
 运行时作为 MCP 兼容 AI 客户端（Claude Desktop、VS Code Copilot、Cursor 等）与运行 CesiumJS 的浏览器之间的桥梁。它将 MCP 工具调用转换为 WebSocket 命令，由 [cesium-mcp-bridge](https://www.npmjs.com/package/cesium-mcp-bridge) 在浏览器端执行。
 
+npm 包会直接携带浏览器 Bridge bundle，因此 `http://localhost:9100/` 内置 Viewer 不再依赖 unpkg 回退；CesiumJS 本身仍从 Cesium 官方 CDN 加载。
+
 支持两种传输模式：
 
 | 传输方式 | 适用场景 | 协议 |

--- a/packages/cesium-mcp-runtime/package.json
+++ b/packages/cesium-mcp-runtime/package.json
@@ -28,7 +28,7 @@
     "dev": "tsx src/index.ts",
     "demo": "npx serve demo -l 3210 --no-clipboard",
     "demo:server": "tsx src/demo-server.ts",
-    "build": "tsup"
+    "build": "tsup && node ../../scripts/copy-runtime-bridge.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/node": "^2.0.0",

--- a/packages/cesium-mcp-runtime/src/index.ts
+++ b/packages/cesium-mcp-runtime/src/index.ts
@@ -371,6 +371,8 @@ function _findLocalBridgeBundle(): string | null {
   const here = dirname(fileURLToPath(import.meta.url))
   const file = 'cesium-mcp-bridge.browser.global.js'
   const candidates = [
+    // npm package: the Runtime ships the browser bundle in its own dist.
+    join(here, file),
     // monorepo: runtime/dist → ../../cesium-mcp-bridge/dist
     join(here, '..', '..', 'cesium-mcp-bridge', 'dist', file),
     // npm install: node_modules/cesium-mcp-runtime/dist → node_modules/cesium-mcp-bridge/dist

--- a/scripts/copy-runtime-bridge.mjs
+++ b/scripts/copy-runtime-bridge.mjs
@@ -1,0 +1,16 @@
+import { copyFile, mkdir, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const file = 'cesium-mcp-bridge.browser.global.js'
+const source = join(root, 'packages', 'cesium-mcp-bridge', 'dist', file)
+const target = join(root, 'packages', 'cesium-mcp-runtime', 'dist', file)
+
+await stat(source).catch(() => {
+  throw new Error(`Build cesium-mcp-bridge before cesium-mcp-runtime: ${source}`)
+})
+await mkdir(dirname(target), { recursive: true })
+await copyFile(source, target)
+
+console.log(`Copied browser Bridge bundle to ${target}`)

--- a/scripts/run-packed-runtime-e2e.mjs
+++ b/scripts/run-packed-runtime-e2e.mjs
@@ -1,0 +1,312 @@
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { chromium } from 'playwright'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const npmCli = process.env.npm_execpath
+  ?? resolve(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')
+const requestedRuntime = process.argv[2] === '--runtime' ? process.argv[3] : undefined
+const temp = await mkdtemp(join(tmpdir(), 'cesium-mcp-packed-e2e-'))
+const artifactsDir = join(temp, 'artifacts')
+const installDir = join(temp, 'install')
+const cesiumDir = resolve(root, 'node_modules', 'cesium', 'Build', 'Cesium')
+
+let runtime
+let browser
+let runtimeStdout = ''
+let runtimeStderr = ''
+const pageErrors = []
+
+async function runNpm(args) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(process.execPath, [npmCli, ...args], {
+      cwd: root,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', chunk => { stdout += chunk.toString() })
+    child.stderr.on('data', chunk => { stderr += chunk.toString() })
+    child.on('error', rejectPromise)
+    child.on('exit', (code) => {
+      if (code === 0) resolvePromise({ stdout, stderr })
+      else rejectPromise(new Error(`npm ${args[0]} exited with code ${code}:\n${stderr}`))
+    })
+  })
+}
+
+async function getFreePort() {
+  const server = createServer()
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise)
+    server.listen(0, '127.0.0.1', resolvePromise)
+  })
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  await new Promise(resolvePromise => server.close(resolvePromise))
+  if (!port) throw new Error('Failed to allocate a local E2E port')
+  return port
+}
+
+async function installRuntime() {
+  if (requestedRuntime) {
+    await runNpm([
+      'install',
+      '--prefix', installDir,
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      requestedRuntime,
+    ])
+    return
+  }
+
+  await mkdir(artifactsDir, { recursive: true })
+  const { stdout } = await runNpm([
+    'pack',
+    './packages/cesium-mcp-contracts',
+    './packages/cesium-mcp-runtime',
+    '--pack-destination', artifactsDir,
+    '--json',
+  ])
+  const packed = JSON.parse(stdout)
+  const contracts = packed.find(item => item.name === 'cesium-mcp-contracts')
+  const runtimePackage = packed.find(item => item.name === 'cesium-mcp-runtime')
+  if (!contracts || !runtimePackage) throw new Error('npm pack omitted a required package')
+
+  await runNpm([
+    'install',
+    '--prefix', installDir,
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    join(artifactsDir, contracts.filename),
+    join(artifactsDir, runtimePackage.filename),
+  ])
+}
+
+async function waitForRuntime(baseUrl) {
+  const deadline = Date.now() + 20_000
+  while (Date.now() < deadline) {
+    if (runtime.exitCode !== null) {
+      throw new Error(`Runtime exited early with code ${runtime.exitCode}`)
+    }
+    try {
+      const response = await fetch(`${baseUrl}/api/status`)
+      if (response.ok) return response.json()
+    } catch {
+      // Runtime is still starting.
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
+  }
+  throw new Error(`Timed out waiting for Runtime at ${baseUrl}`)
+}
+
+function contentType(path) {
+  return {
+    '.css': 'text/css',
+    '.gif': 'image/gif',
+    '.glsl': 'text/plain',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.js': 'application/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.wasm': 'application/wasm',
+    '.webp': 'image/webp',
+    '.xml': 'application/xml',
+  }[extname(path).toLowerCase()] ?? 'application/octet-stream'
+}
+
+async function launchBrowser() {
+  try {
+    return await chromium.launch({ headless: true })
+  } catch (error) {
+    if (process.platform !== 'win32') throw error
+    return chromium.launch({ channel: 'chrome', headless: true })
+  }
+}
+
+async function postCommand(baseUrl, sessionId, action, params = {}) {
+  const response = await fetch(`${baseUrl}/api/relay`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action, params, sessionId }),
+  })
+  const payload = await response.json()
+  if (!response.ok || !payload.ok) {
+    throw new Error(`${action} failed: ${JSON.stringify(payload)}`)
+  }
+  return payload.result
+}
+
+try {
+  await installRuntime()
+
+  const runtimePackagePath = join(
+    installDir,
+    'node_modules',
+    'cesium-mcp-runtime',
+    'package.json',
+  )
+  const runtimePackage = JSON.parse(await readFile(runtimePackagePath, 'utf8'))
+  const runtimeEntry = join(
+    installDir,
+    'node_modules',
+    'cesium-mcp-runtime',
+    'dist',
+    'cli.js',
+  )
+  const bundledBridge = join(
+    installDir,
+    'node_modules',
+    'cesium-mcp-runtime',
+    'dist',
+    'cesium-mcp-bridge.browser.global.js',
+  )
+  await stat(runtimeEntry)
+  await stat(bundledBridge)
+
+  const viewerPort = await getFreePort()
+  const mcpPort = await getFreePort()
+  const baseUrl = `http://127.0.0.1:${viewerPort}`
+  const sessionId = 'packed-e2e'
+
+  runtime = spawn(
+    process.execPath,
+    [runtimeEntry, '--transport', 'http', '--port', String(mcpPort)],
+    {
+      cwd: installDir,
+      env: {
+        ...process.env,
+        CESIUM_WS_PORT: String(viewerPort),
+        MCP_TRANSPORT: 'http',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+  runtime.stdout.on('data', chunk => { runtimeStdout += chunk.toString() })
+  runtime.stderr.on('data', chunk => { runtimeStderr += chunk.toString() })
+
+  await waitForRuntime(baseUrl)
+
+  const [viewerResponse, bundleResponse, toolsResponse] = await Promise.all([
+    fetch(`${baseUrl}/?session=${sessionId}`),
+    fetch(`${baseUrl}/bridge.js`),
+    fetch(`${baseUrl}/api/tools?toolsets=view`),
+  ])
+  const viewerHtml = await viewerResponse.text()
+  const bundleSource = await bundleResponse.text()
+  const toolsPayload = await toolsResponse.json()
+  const flyTo = toolsPayload.tools.find(tool => tool.name === 'flyTo')
+
+  if (!viewerResponse.ok || !viewerHtml.includes('Cesium MCP Viewer')) {
+    throw new Error('Packed Runtime did not serve the built-in Viewer')
+  }
+  if (!bundleResponse.ok || !bundleSource.includes('CesiumMcpBridge')) {
+    throw new Error('Packed Runtime did not serve its local browser Bridge bundle')
+  }
+  if (!flyTo?.outputSchema?.required?.includes('success')) {
+    throw new Error('Packed Runtime did not expose the canonical flyTo output schema')
+  }
+
+  browser = await launchBrowser()
+  const context = await browser.newContext()
+  await context.route('**/*', async (route) => {
+    const url = new URL(route.request().url())
+    if (url.origin === baseUrl) {
+      await route.continue()
+      return
+    }
+
+    const marker = '/Build/Cesium/'
+    if (url.hostname === 'cesium.com' && url.pathname.includes(marker)) {
+      const resource = decodeURIComponent(url.pathname.split(marker)[1] ?? '')
+      const localPath = resolve(cesiumDir, ...resource.split('/'))
+      const relativePath = relative(cesiumDir, localPath)
+      if (
+        relativePath === '..'
+        || relativePath.startsWith(`..${sep}`)
+        || isAbsolute(relativePath)
+      ) {
+        await route.abort()
+        return
+      }
+      try {
+        await route.fulfill({
+          body: await readFile(localPath),
+          contentType: contentType(localPath),
+        })
+      } catch {
+        await route.abort()
+      }
+      return
+    }
+
+    await route.abort()
+  })
+
+  const page = await context.newPage()
+  page.on('pageerror', error => pageErrors.push(error.message))
+  await page.goto(`${baseUrl}/?session=${sessionId}`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 30_000,
+  })
+  await page.waitForFunction(
+    () => document.querySelector('#s')?.textContent === 'Connected',
+    undefined,
+    { timeout: 30_000 },
+  )
+
+  const setViewResult = await postCommand(baseUrl, sessionId, 'setView', {
+    longitude: 116.3972,
+    latitude: 39.9163,
+    height: 1200,
+    heading: 0,
+    pitch: -90,
+  })
+  const getViewResult = await postCommand(baseUrl, sessionId, 'getView')
+  const view = getViewResult?.data
+  if (!setViewResult?.success || !getViewResult?.success) {
+    throw new Error(
+      `Packed Viewer command execution did not succeed: ${JSON.stringify({
+        setViewResult,
+        getViewResult,
+      })}`,
+    )
+  }
+  if (
+    Math.abs(view.longitude - 116.3972) > 0.01
+    || Math.abs(view.latitude - 39.9163) > 0.01
+  ) {
+    throw new Error(`Packed Viewer returned an unexpected camera state: ${JSON.stringify(view)}`)
+  }
+
+  console.log(JSON.stringify({
+    runtime: runtimePackage.version,
+    source: requestedRuntime ?? 'local npm pack',
+    viewer: 'connected',
+    bridge: 'local bundle',
+    tools: toolsPayload.tools.length,
+    command: 'setView -> getView',
+  }))
+} catch (error) {
+  console.error(error)
+  if (pageErrors.length > 0) console.error(`Page errors:\n${pageErrors.join('\n')}`)
+  if (runtimeStdout) console.error(`Runtime stdout:\n${runtimeStdout}`)
+  if (runtimeStderr) console.error(`Runtime stderr:\n${runtimeStderr}`)
+  process.exitCode = 1
+} finally {
+  if (browser) await browser.close()
+  if (runtime && runtime.exitCode === null) {
+    runtime.kill()
+    await new Promise(resolvePromise => runtime.once('exit', resolvePromise))
+  }
+  await rm(temp, { recursive: true, force: true })
+}


### PR DESCRIPTION
## What changed

- ship the browser Bridge bundle inside `cesium-mcp-runtime`
- prefer the Runtime-owned bundle for `/bridge.js`
- add a packed-artifact E2E that installs clean tarballs, opens the real Viewer, connects WebSocket, and runs `setView -> getView`
- run the packed E2E on Node 22 in CI
- document the self-contained Viewer artifact in English and Chinese

## Why

The published `cesium-mcp-runtime@1.145.0` package did not contain a browser Bridge bundle. A fresh installation therefore returned 404 for the local `/bridge.js` asset and silently depended on the unpkg fallback, despite the Viewer being described as locally bundled.

## Impact

The built-in Viewer now works from a clean Runtime installation without downloading the Bridge implementation from unpkg. CesiumJS assets continue to use the official Cesium CDN.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx vitest run` (315 tests)
- `npm run docs:build`
- `npm run test:conformance:mcp` (28/28)
- `npm run test:e2e:packed` (real Viewer connected; `setView -> getView` passed)
- `npm pack ./packages/cesium-mcp-runtime --dry-run --json` includes `dist/cesium-mcp-bridge.browser.global.js`
