### PR TITLE
fix: restore browser agent globe startup

### DIFF
--- a/examples/browser-agent/index.html
+++ b/examples/browser-agent/index.html
@@ -10,7 +10,7 @@
   <meta property="og:image" content="https://cesium-browser-agent.pages.dev/favicon.svg">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="shortcut icon" href="/favicon.svg">
-  <script src="/packages/cesium-mcp-webmcp/dist/cesium-mcp-webmcp.browser.global.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/cesium-mcp-webmcp@0.2.4/dist/cesium-mcp-webmcp.browser.global.js"></script>
   <script src="./tool-router.js"></script>
   <script src="./function-tools.js"></script>
   <script src="./agent-response.js"></script>
@@ -939,7 +939,8 @@ function setWebMcpStatus(state, titleKey, detailKey, variables = {}) {
 // Cesium Init
 // ============================================================
 const CESIUM_SCRIPT_URL = 'https://cesium.com/downloads/cesiumjs/releases/1.143/Build/Cesium/Cesium.js'
-const BRIDGE_SCRIPT_URL = '/packages/cesium-mcp-bridge/dist/cesium-mcp-bridge.browser.global.js'
+const NATURAL_EARTH_URL = 'https://cesium.com/downloads/cesiumjs/releases/1.143/Build/Cesium/Assets/Textures/NaturalEarthII'
+const BRIDGE_SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/cesium-mcp-bridge@1.145.1/dist/cesium-mcp-bridge.browser.global.js'
 const BRIDGE_FALLBACK_URL = 'https://cdn.jsdelivr.net/npm/cesium-mcp-bridge@latest/dist/cesium-mcp-bridge.browser.global.js'
 
 function loadCesiumRuntime() {
@@ -1021,8 +1022,13 @@ async function initializeCesium() {
     Cesium.Ion.defaultAccessToken = CONFIG.ionToken;
   }
 
+  const baseLayer = new Cesium.ImageryLayer(
+    await Cesium.TileMapServiceImageryProvider.fromUrl(NATURAL_EARTH_URL),
+  )
+
   const viewer = new Cesium.Viewer('cesiumContainer', {
-    terrain: Cesium.Terrain.fromWorldTerrain(),
+    baseLayer,
+    ...(CONFIG.ionToken ? { terrain: Cesium.Terrain.fromWorldTerrain() } : {}),
     baseLayerPicker: false,
     geocoder: false,
     homeButton: false,

--- a/examples/browser-agent/index.test.ts
+++ b/examples/browser-agent/index.test.ts
@@ -41,9 +41,22 @@ describe('browser-agent startup order', () => {
     expect(html).toContain("script.src = CESIUM_SCRIPT_URL")
   })
 
+  it('renders a token-free globe before optional Cesium ion configuration', () => {
+    expect(html).toContain('Cesium.TileMapServiceImageryProvider.fromUrl(NATURAL_EARTH_URL)')
+    expect(html).toContain("...(CONFIG.ionToken ? { terrain: Cesium.Terrain.fromWorldTerrain() } : {})")
+    expect(html).not.toContain('terrain: Cesium.Terrain.fromWorldTerrain(),')
+  })
+
   it('registers tools without loading the Cesium-dependent bridge bundle', () => {
     expect(html).not.toContain('<script\n    src="../../packages/cesium-mcp-bridge')
-    expect(html).toContain('/packages/cesium-mcp-webmcp/dist/cesium-mcp-webmcp.browser.global.js')
+    expect(html).not.toContain("BRIDGE_SCRIPT_URL = '/packages/cesium-mcp-bridge/")
+    expect(html).toContain(
+      "BRIDGE_SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/cesium-mcp-bridge@1.145.1/dist/cesium-mcp-bridge.browser.global.js'",
+    )
+    expect(html).not.toContain('src="/packages/cesium-mcp-webmcp/')
+    expect(html).toContain(
+      'https://cdn.jsdelivr.net/npm/cesium-mcp-webmcp@0.2.4/dist/cesium-mcp-webmcp.browser.global.js',
+    )
     expect(html).toContain("await CesiumMcpWebMcp.registerCesiumWebMcp(executor, { toolsets: 'all' })")
     expect(html).not.toContain('document.modelContext.registerTool')
     expect(html).toContain('loadScript(BRIDGE_SCRIPT_URL)')


### PR DESCRIPTION
## Summary

- load the published WebMCP and Bridge browser bundles instead of undeployed repository paths
- render Natural Earth imagery without requiring a Cesium ion token
- only enable Cesium World Terrain when a token is configured
- add browser-agent startup regressions

## Verification

- 38 browser-agent tests pass
- local Cloudflare Pages runtime renders the globe without an ion token
- deployed production asset content verified