### PR TITLE
fix: initialize browser agent globe on load

### DIFF
--- a/examples/browser-agent/index.html
+++ b/examples/browser-agent/index.html
@@ -1004,17 +1004,6 @@ function initCesium() {
   return cesiumInitPromise
 }
 
-function armCesiumActivation() {
-  const events = ['pointerdown', 'keydown']
-  const activate = () => {
-    events.forEach(event => window.removeEventListener(event, activate))
-    initCesium().catch(error => {
-      console.error('[Agent] Cesium initialization failed:', error)
-    })
-  }
-  events.forEach(event => window.addEventListener(event, activate, { once: true, passive: true }))
-}
-
 async function initializeCesium() {
   await loadCesiumRuntime()
   await loadBridgeRuntime()
@@ -1420,8 +1409,10 @@ function initToolsList() {
 // ============================================================
 async function bootstrap() {
   applyLocale()
-  armCesiumActivation()
   refreshAiUsage()
+  initCesium().catch(error => {
+    console.error('[Agent] Cesium initialization failed:', error)
+  })
   try {
     await registerPageWebMcpTools()
   } catch (error) {

--- a/examples/browser-agent/index.test.ts
+++ b/examples/browser-agent/index.test.ts
@@ -24,16 +24,18 @@ describe('browser-agent startup order', () => {
     expect(html).toContain('https://cesium-browser-agent.pages.dev/favicon.svg')
   })
 
-  it('registers WebMCP without starting Cesium during page load', () => {
+  it('starts Cesium immediately without blocking WebMCP registration', () => {
     const bootstrapStart = html.indexOf('async function bootstrap()')
+    const cesiumInitialization = html.indexOf('initCesium().catch', bootstrapStart)
     const registration = html.indexOf('await registerPageWebMcpTools()', bootstrapStart)
     const bootstrapEnd = html.indexOf('\n}', bootstrapStart)
     const bootstrap = html.slice(bootstrapStart, bootstrapEnd)
 
     expect(bootstrapStart).toBeGreaterThan(-1)
+    expect(cesiumInitialization).toBeGreaterThan(bootstrapStart)
     expect(registration).toBeGreaterThan(bootstrapStart)
-    expect(bootstrap).not.toContain('initCesium()')
-    expect(bootstrap).toContain('armCesiumActivation()')
+    expect(cesiumInitialization).toBeLessThan(registration)
+    expect(bootstrap).not.toContain('armCesiumActivation()')
   })
 
   it('does not parser-block startup on the remote Cesium script', () => {


### PR DESCRIPTION
## Summary

- initialize Cesium immediately during page bootstrap
- keep WebMCP registration independent from Viewer readiness
- remove the first pointer/keyboard interaction gate
- add a startup regression asserting initialization precedes WebMCP registration

## Verification

- 38 browser-agent tests pass
- fresh local Pages load renders the globe without any click or key press