### PR TITLE
Harden WebMCP lifecycle and standardize one-package setup

### DIFF
--- a/.changeset/bright-globes-register.md
+++ b/.changeset/bright-globes-register.md
@@ -1,0 +1,5 @@
+---
+'cesium-mcp-webmcp': patch
+---
+
+Harden WebMCP lifecycle registration with feature detection, inspectable tool payloads, and immediate cancellation of superseded batches.

--- a/.changeset/bright-globes-register.md
+++ b/.changeset/bright-globes-register.md
@@ -2,4 +2,4 @@
 'cesium-mcp-webmcp': patch
 ---
 
-Harden WebMCP lifecycle registration with feature detection, inspectable tool payloads, and immediate cancellation of superseded batches.
+Add a one-package Viewer integration and harden WebMCP lifecycle registration with feature detection, inspectable tool payloads, and immediate cancellation of superseded batches.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 <img width="2172" height="724" alt="ChatGPT Image 2026年7月5日 22_13_19" src="https://github.com/user-attachments/assets/098dcbef-e0bc-4214-8adf-b80a29e50e65" />
 <div align="center">
-  <p><strong>The minimum-overhead way to add AI commands to CesiumJS</strong></p>
+  <p><strong>A protocol-agnostic Cesium AI control runtime for MCP, WebMCP, function calling, and browser agents</strong></p>
 
   <p><a href="packages/cesium-mcp-bridge/">cesium-mcp-bridge</a> is the protocol-agnostic Cesium command executor. Separate adapters expose it to <strong>browser-only agents</strong>, <strong>WebMCP browser agents</strong>, <strong>function calling</strong>, or <strong>MCP</strong> — your choice.</p>
 
   <p>Four integration paths: <a href="examples/browser-agent/">Browser Agent</a> (simplest, zero backend) · WebMCP (page-local browser tools) · function calling (embed in your web app) · <a href="packages/cesium-mcp-runtime/">MCP runtime</a> (Claude Desktop / Cursor / Dify)</p>
+
+  <p>The local Runtime is only required for external MCP hosts. Browser Agent, WebMCP, and function-calling integrations execute the same commands directly in the web application.</p>
 
   <p><a href="https://cesium-browser-agent.pages.dev/"><strong>Try it now</strong></a> — open the live browser demo, no install, no signup.</p>
 
@@ -82,6 +84,14 @@ flowchart LR
 ```
 
 The bridge remains the execution core, while contracts and protocol adapters stay separate. Pick whichever driver matches your scenario — they all reach the same Cesium command layer. On WebMCP-capable browsers, `cesium-mcp-webmcp` can expose 61 browser-safe commands in 12 selectable toolsets through `document.modelContext` without adding an MCP transport or backend server.
+
+### Relationship to the CesiumGS AI ecosystem
+
+CesiumGS's newer AI work is split between [`cesiumjs-ai-starter-app`](https://github.com/CesiumGS/cesiumjs-ai-starter-app), a deployable application template, and [`cesiumjs-skills`](https://github.com/CesiumGS/cesiumjs-skills), development-time guidance for coding agents. The earlier [`cesium-ai-integrations`](https://github.com/CesiumGS/cesium-ai-integrations) repository contains the first-generation experiments and community contributions that helped explore this space.
+
+`cesium-mcp` is an independent runtime and integration toolkit, not a continuation of the earlier WebSocket-only reference architecture. Its reusable Bridge and shared contracts work unchanged across browser-only function calling, native WebMCP, standard MCP over stdio/HTTP, and embedded desktop shells. A local WebSocket bridge is used only when an external MCP host needs to reach a live browser Viewer; it is not required for the hosted demo or page-local integrations.
+
+The project author was an early contributor to `CesiumGS/cesium-ai-integrations`, contributing the Imagery server, Terrain server, and unified MCP Gateway. Those experiments informed this project's multi-protocol architecture, while the implementation, release lifecycle, and roadmap remain independent.
 
 ## Quick Start
 
@@ -193,8 +203,6 @@ Tools are organized into **12 toolsets**. Default mode enables 4 core toolsets (
 | heatmap | `addHeatmap` |
 | scene | `setSceneOptions`, `setPostProcess`, `setIonToken` (Runtime only) |
 | geolocation | `geocode` |
-
-> **Relationship with CesiumGS official MCP servers**: The `camera`, `entity-ext`, and `animation` toolsets natively fuse capabilities from [CesiumGS/cesium-mcp-server](https://github.com/CesiumGS/cesium-mcp-server) (Camera Server, Entity Server, Animation Server) into this project's unified bridge architecture. This means you get all official functionality plus additional tools — in a single MCP server, without running multiple processes.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://github.com/user-attachments/assets/8a40565a-fcdd-47bf-ae67-bc870611c908
 |--------|------|--------|-------|
 | **cesium-mcp-contracts** | Transport-neutral names, descriptions, and JSON Schemas for browser tools | New shared layer | [source](packages/cesium-mcp-contracts/) |
 | **cesium-mcp-bridge** | Protocol- and transport-free Cesium command executor (60+ commands) | Mainline, actively iterated | [![npm](https://img.shields.io/npm/v/cesium-mcp-bridge)](https://www.npmjs.com/package/cesium-mcp-bridge) · [source](packages/cesium-mcp-bridge/) |
-| **cesium-mcp-webmcp** | Native `document.modelContext` adapter for Cesium tool contracts | New browser adapter | [source](packages/cesium-mcp-webmcp/) |
+| **cesium-mcp-webmcp** | One-package Viewer integration plus the native `document.modelContext` adapter | Browser integration | [source](packages/cesium-mcp-webmcp/) |
 | **examples/webmcp-integration** | Focused npm + Vite integration without a chat UI or MCP server | Developer example | [example](examples/webmcp-integration/) |
 | **examples/browser-agent** | Browser-only AI agent with automatic WebMCP exposure | Recommended | [example](examples/browser-agent/) · [live demo](https://cesium-browser-agent.pages.dev/) |
 | **cesium-mcp-runtime** | MCP server (stdio + HTTP) | Stable MCP SDK v2 | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime) · [source](packages/cesium-mcp-runtime/) |
@@ -117,15 +117,13 @@ Open `http://localhost:4173/examples/browser-agent/`, click **Start**, then insp
 Application developers install the adapter separately. End users only open the integrated website; they do not install npm packages or run an MCP server.
 
 ```bash
-npm install cesium cesium-mcp-bridge cesium-mcp-webmcp
+npm install cesium-mcp-webmcp
 ```
 
 ```js
-import { CesiumBridge } from 'cesium-mcp-bridge'
-import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import { registerCesiumViewerWebMcp } from 'cesium-mcp-webmcp/viewer'
 
-const bridge = new CesiumBridge(viewer)
-const registration = await registerCesiumWebMcp(bridge, {
+const registration = await registerCesiumViewerWebMcp(viewer, {
   toolsets: 'all',
   excludeTools: ['geocode'], // add your own browser geocoder to expose this tool
 })

--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ See [examples/browser-agent/index.html](examples/browser-agent/index.html) for a
 
 ### Path 3 — Use from Claude Desktop / Cursor / Dify (MCP)
 
-Install bridge as in Path 2, then start the MCP runtime:
+Ordinary MCP users need only the Runtime package. It includes the browser Bridge bundle and a built-in Viewer at `http://localhost:9100/`; install `cesium-mcp-bridge` separately only when integrating a custom page.
 
 ```bash
 # Stable channel — npm latest, MCP SDK v2
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 
 # HTTP mode
-npx cesium-mcp-runtime --transport http --port 3000
+npx -y cesium-mcp-runtime --transport http --port 3000
 ```
 
 The stable release serves existing MCP `2025-11-25` clients and the new

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -156,14 +156,14 @@ const bridge = new CesiumBridge(viewer);
 
 ### 路径 3 — 从 Claude Desktop / Cursor / Dify 调用（MCP）
 
-按路径 2 安装 bridge，然后启动 MCP runtime：
+普通 MCP 用户只需要 Runtime 一个包。它已经包含浏览器 Bridge bundle，并在 `http://localhost:9100/` 提供内置 Viewer；只有接入自定义页面时才需要单独安装 `cesium-mcp-bridge`。
 
 ```bash
 # 稳定通道 — npm latest，MCP SDK v2
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 
 # HTTP 模式
-npx cesium-mcp-runtime --transport http --port 3000
+npx -y cesium-mcp-runtime --transport http --port 3000
 ```
 
 稳定版通过同一个 stdio/HTTP 入口同时支持现有 MCP `2025-11-25`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,11 +3,13 @@
 
   <h1>Cesium MCP</h1>
 
-  <p><strong>给 CesiumJS 加 AI 命令的最小代价</strong></p>
+  <p><strong>面向 MCP、WebMCP、Function Calling 与浏览器 Agent 的协议无关 Cesium AI 控制 Runtime</strong></p>
 
   <p><a href="packages/cesium-mcp-bridge/">cesium-mcp-bridge</a> 是协议无关的 Cesium 命令执行核心；独立适配层可将它接入 <strong>纯浏览器 Agent</strong>、<strong>WebMCP 浏览器 Agent</strong>、<strong>function calling</strong> 或 <strong>MCP</strong>。</p>
 
   <p>四种接入方式任选其一：<a href="examples/browser-agent/">浏览器 Agent</a>（最简单，零后端）· WebMCP（页面内浏览器工具）· function calling（自托管 Web 应用嵌入）· <a href="packages/cesium-mcp-runtime/">MCP runtime</a>（接 Claude Desktop / Cursor / Dify）</p>
+
+  <p>只有外部 MCP Host 接入时才需要本地 Runtime；浏览器 Agent、WebMCP 和 Function Calling 都可以在 Web 应用中直接执行同一套命令。</p>
 
   <p><a href="https://cesium-browser-agent.pages.dev/"><strong>立即体验</strong></a> — 在线 Demo，零安装、零注册</p>
 
@@ -85,6 +87,14 @@ flowchart LR
 ```
 
 bridge 保持为执行核心，工具契约和协议适配层分别独立。四种驱动方最终都调用同一个 Cesium 命令层，按场景选一种即可。在支持 WebMCP 的浏览器中，`cesium-mcp-webmcp` 可通过 `document.modelContext` 按 12 个工具集暴露 61 个浏览器安全命令，无需增加 MCP 传输层或后端服务器。
+
+### 与 CesiumGS 官方 AI 生态的关系
+
+CesiumGS 新一代 AI 工作主要拆分到两个仓库：[`cesiumjs-ai-starter-app`](https://github.com/CesiumGS/cesiumjs-ai-starter-app) 提供可部署的应用模板，[`cesiumjs-skills`](https://github.com/CesiumGS/cesiumjs-skills) 为编码 Agent 提供开发期知识。较早的 [`cesium-ai-integrations`](https://github.com/CesiumGS/cesium-ai-integrations) 则保留了这一方向的第一代实验和社区贡献。
+
+`cesium-mcp` 是独立的 Runtime 与集成工具包，不是早期纯 WebSocket 参考架构的延续。它的 Bridge 和共享工具契约可以原样用于纯浏览器 Function Calling、原生 WebMCP、stdio/HTTP 标准 MCP，以及内嵌桌面应用。只有外部 MCP Host 需要连接浏览器中的实时 Viewer 时才使用本地 WebSocket Bridge；在线 Demo 和页面内接入都不依赖它。
+
+项目作者曾参与 `CesiumGS/cesium-ai-integrations` 的早期建设，贡献 Imagery Server、Terrain Server 和统一 MCP Gateway。这些实验为当前的多协议架构提供了经验，但本项目的实现、发布周期和路线图保持独立。
 
 ## 快速开始
 
@@ -195,8 +205,6 @@ MCP 客户端配置：
 | heatmap | `addHeatmap` |
 | scene | `setSceneOptions`, `setPostProcess`, `setIonToken`（仅 Runtime） |
 | geolocation | `geocode` |
-
-> **与 CesiumGS 官方 MCP 服务器的关系**：`camera`、`entity-ext` 和 `animation` 工具集原生融合了 [CesiumGS/cesium-mcp-server](https://github.com/CesiumGS/cesium-mcp-server)（Camera Server、Entity Server、Animation Server）的能力到本项目的统一 Bridge 架构中。一个 MCP 服务器即可获得全部官方功能加更多工具，无需运行多个进程。
 
 ## 示例
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,7 @@ https://github.com/user-attachments/assets/8a40565a-fcdd-47bf-ae67-bc870611c908
 |------|------|------|------|
 | **cesium-mcp-contracts** | 与传输无关的浏览器工具名称、说明和 JSON Schema | 新增共享层 | [源码](packages/cesium-mcp-contracts/) |
 | **cesium-mcp-bridge** | 与协议、传输无关的 Cesium 命令执行核心（60+ 命令） | 主线，持续迭代 | [![npm](https://img.shields.io/npm/v/cesium-mcp-bridge)](https://www.npmjs.com/package/cesium-mcp-bridge) · [源码](packages/cesium-mcp-bridge/) |
-| **cesium-mcp-webmcp** | 基于原生 `document.modelContext` 的 Cesium 工具适配层 | 新增浏览器适配层 | [源码](packages/cesium-mcp-webmcp/) |
+| **cesium-mcp-webmcp** | 一包完成 Viewer 接入，并提供原生 `document.modelContext` 适配层 | 浏览器接入 | [源码](packages/cesium-mcp-webmcp/) |
 | **examples/webmcp-integration** | 不包含聊天 UI 和 MCP 服务的 npm + Vite 接入示例 | 开发者示例 | [示例](examples/webmcp-integration/) |
 | **examples/browser-agent** | 纯浏览器 AI Agent，自动暴露 WebMCP 工具 | 推荐入口 | [示例](examples/browser-agent/) · [在线 demo](https://cesium-browser-agent.pages.dev/) |
 | **cesium-mcp-runtime** | MCP 服务器（stdio + HTTP） | 稳定版 MCP SDK v2 | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime) · [源码](packages/cesium-mcp-runtime/) |
@@ -120,15 +120,13 @@ npx serve . -l 4173
 应用开发者需要单独安装适配包；普通用户只需打开已经接入的网站，不需要安装 npm 包，也不需要启动 MCP 服务。
 
 ```bash
-npm install cesium cesium-mcp-bridge cesium-mcp-webmcp
+npm install cesium-mcp-webmcp
 ```
 
 ```js
-import { CesiumBridge } from 'cesium-mcp-bridge'
-import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import { registerCesiumViewerWebMcp } from 'cesium-mcp-webmcp/viewer'
 
-const bridge = new CesiumBridge(viewer)
-const registration = await registerCesiumWebMcp(bridge, {
+const registration = await registerCesiumViewerWebMcp(viewer, {
   toolsets: 'all',
   excludeTools: ['geocode'], // 如需该工具，请接入自己的浏览器地理编码处理器
 })

--- a/docs/api/dev.md
+++ b/docs/api/dev.md
@@ -10,7 +10,7 @@ and `2026-07-28` clients.
 ## Installation & Run
 
 ```bash
-npx cesium-mcp-dev
+npx -y cesium-mcp-dev
 ```
 
 ## IDE Configuration

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime)
 
 ::: tip Release channels
-- Stable: `npx cesium-mcp-runtime` → npm `latest`
+- Stable: `npx -y cesium-mcp-runtime` → npm `latest`
 
 The stable release supports MCP `2025-11-25` and `2026-07-28`, uses the
 stable TypeScript SDK v2, and passes the official `server-stateless`
@@ -15,8 +15,10 @@ conformance scenario (28/28).
 ## Installation & Run
 
 ```bash
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 ```
+
+Open `http://localhost:9100/` for the included Viewer. The default path does not require a separate Bridge package.
 
 Or install globally:
 
@@ -77,6 +79,8 @@ cesium-mcp-runtime
 Tools are organized into **12 toolsets**. By default, 4 core toolsets are enabled (30 tools). Set `CESIUM_TOOLSETS=all` for everything, or let the AI discover and activate toolsets dynamically. Shared titles, behavior annotations, localized descriptions, defaults, input validation, advertised output schemas, and structured results come from the canonical JSON Schemas in `cesium-mcp-contracts`. Tool calls retain text `content` for older clients.
 
 The Runtime npm artifact includes the browser Bridge bundle served by `/bridge.js`. The built-in Viewer does not depend on an unpkg fallback, while CesiumJS assets continue to load from the official Cesium CDN.
+
+The default MCP path therefore needs only `cesium-mcp-runtime`. A separate `cesium-mcp-bridge` installation is for custom CesiumJS pages, not built-in Viewer users.
 
 ### Toolsets
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -7,10 +7,10 @@
 **Symptom**: The browser console shows `WebSocket connection to 'ws://localhost:9100' failed`.
 
 **Solutions**:
-1. Make sure `cesium-mcp-runtime` is running: `npx cesium-mcp-runtime`
+1. Make sure `cesium-mcp-runtime` is running: `npx -y cesium-mcp-runtime`
 2. Check the port — if port 9100 is in use, set a custom port:
    ```bash
-   CESIUM_WS_PORT=9200 npx cesium-mcp-runtime
+   CESIUM_WS_PORT=9200 npx -y cesium-mcp-runtime
    ```
    The runtime will automatically listen on the new port.
 3. If using HTTPS, the browser blocks mixed content (wss:// is required). Use a reverse proxy or tunnel (e.g. ngrok).
@@ -30,8 +30,8 @@
 
 The runtime can't find a connected browser session.
 
-1. Open your CesiumJS app in the browser
-2. Check that the bridge initialization code is running (look for `[CesiumBridge] connected` in browser console)
+1. Open the built-in Viewer at `http://localhost:9100/?session=default`, or open your custom CesiumJS page
+2. For a custom page, check that its Runtime WebSocket connection is initialized
 3. If using multiple tabs, set unique `sessionId` for each
 
 ### Only some tools are available
@@ -39,7 +39,7 @@ The runtime can't find a connected browser session.
 By default, only core toolsets are enabled. To enable all 62 command tools:
 
 ```bash
-CESIUM_TOOLSETS=all npx cesium-mcp-runtime
+CESIUM_TOOLSETS=all npx -y cesium-mcp-runtime
 ```
 
 Or use dynamic discovery — ask your AI agent: *"List available toolsets"*, then *"Enable the animation toolset"*.
@@ -68,7 +68,7 @@ The bridge doesn't handle tokens — they are managed by your CesiumJS applicati
 Set the `CESIUM_WS_PORT` environment variable:
 
 ```bash
-CESIUM_WS_PORT=9200 npx cesium-mcp-runtime
+CESIUM_WS_PORT=9200 npx -y cesium-mcp-runtime
 ```
 
 ### Can I use remote/cloud mode?
@@ -76,7 +76,7 @@ CESIUM_WS_PORT=9200 npx cesium-mcp-runtime
 Yes. The runtime supports Streamable HTTP mode for remote access:
 
 ```bash
-npx cesium-mcp-runtime --mode http --port 3000
+npx -y cesium-mcp-runtime --transport http --port 3000
 ```
 
 Or use the hosted endpoint at `https://mcp.gpb.cc`.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -4,56 +4,44 @@ This guide configures the Node.js MCP runtime for desktop clients and workflow p
 
 ## Prerequisites
 
-- **Node.js** 22 or higher
-- A **CesiumJS** application (or use our minimal example)
+- **Node.js** 20 or higher
 - An **MCP-compatible AI client** (Claude Desktop, VS Code Copilot, Cursor, etc.)
+- A separate CesiumJS application is optional; the Runtime includes a ready-to-use Viewer
 
-## Installation
+## One-package quick start
 
 ::: tip MCP SDK v2 is stable
 The npm `latest` release supports existing MCP `2025-11-25` clients and the
 new `2026-07-28` protocol from the same stdio/HTTP entry.
 
 ```bash
-npm install cesium-mcp-bridge
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 ```
 :::
 
-### 1. Add the Bridge to Your CesiumJS App
+For the default MCP experience, `cesium-mcp-runtime` is the only package. It includes the MCP server, WebSocket session routing, browser Bridge bundle, and a built-in Cesium Viewer at `http://localhost:9100/`.
 
-```bash
-npm install cesium-mcp-bridge
-```
-
-Initialize the bridge after creating your Cesium Viewer:
-
-```js
-import { CesiumBridge } from 'cesium-mcp-bridge'
-
-const viewer = new Cesium.Viewer('cesiumContainer')
-const bridge = new CesiumBridge(viewer)
-```
-
-### 2. Start the MCP Runtime
+### Start manually
 
 **stdio mode** (for Claude Desktop, VS Code, Cursor):
 
 ```bash
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 ```
 
 **HTTP mode** (for Dify, n8n, and other HTTP-based AI platforms):
 
 ```bash
-npx cesium-mcp-runtime --transport http --port 3211
+npx -y cesium-mcp-runtime --transport http --port 3211
 ```
 
 This starts a Node.js process that:
 - Exposes MCP tools on the selected transport (stdio or HTTP)
-- Opens a **WebSocket server** on port 9100 (for the browser bridge)
+- Opens a **WebSocket server** on port 9100 for Viewer sessions
+- Serves the built-in Viewer at `http://localhost:9100/`
+- Serves its packaged browser Bridge at `/bridge.js`
 
-### 3. Configure Your AI Agent
+## Configure your AI agent
 
 #### Claude Desktop
 
@@ -105,7 +93,7 @@ Create `.cursor/mcp.json`:
 Start the runtime in HTTP mode first:
 
 ```bash
-npx cesium-mcp-runtime --transport http --port 3211
+npx -y cesium-mcp-runtime --transport http --port 3211
 ```
 
 Then in Dify, add an MCP tool node with:
@@ -123,20 +111,37 @@ Then in Dify, add an MCP tool node with:
 > For Docker-hosted Dify, replace `localhost` with `host.docker.internal`.
 > See the full guide: [examples/dify-integration/](https://github.com/gaopengbin/cesium-mcp/tree/main/examples/dify-integration)
 
-### 4. Try It Out
+## Try it out
 
-Open your CesiumJS app in a browser, then ask your AI agent:
+Open `http://localhost:9100/` in a browser, then ask your AI agent:
 
 > "Fly to the Eiffel Tower"
 
 The agent will call the `flyTo` tool, which routes through the runtime to the bridge, and your globe will animate to Paris.
+
+## Custom CesiumJS application (optional)
+
+Only install `cesium-mcp-bridge` when you want MCP commands to control a Viewer inside your own application instead of the built-in Viewer:
+
+```bash
+npm install cesium-mcp-bridge
+```
+
+```js
+import { CesiumBridge } from 'cesium-mcp-bridge'
+
+const viewer = new Cesium.Viewer('cesiumContainer')
+const bridge = new CesiumBridge(viewer)
+```
+
+Your page also needs to connect that Bridge to the Runtime WebSocket. Use the [minimal custom-page example](https://github.com/gaopengbin/cesium-mcp/tree/main/examples/minimal) as the complete reference. This is an application-development path, not a requirement for ordinary MCP users.
 
 ## IDE-Only Setup (cesium-mcp-dev)
 
 If you just want AI-powered CesiumJS code assistance (no live globe), install the dev server:
 
 ```bash
-npx cesium-mcp-dev
+npx -y cesium-mcp-dev
 ```
 
 This provides:

--- a/docs/guide/webmcp.md
+++ b/docs/guide/webmcp.md
@@ -20,18 +20,21 @@ The HTTPS demo also contains a narrow, path-preserving proxy for its explicitly 
 ## Install in an existing Cesium app
 
 ```bash
-npm install cesium cesium-mcp-bridge cesium-mcp-webmcp
+npm install cesium-mcp-webmcp
 ```
+
+The host application already owns `cesium` and its Viewer. The Bridge and shared contracts are installed transitively, so an existing CesiumJS application adds only one package.
 
 Register the tools after creating your Cesium viewer:
 
 ```ts
-import { CesiumBridge } from 'cesium-mcp-bridge'
-import { isWebMcpSupported, registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import {
+  isWebMcpSupported,
+  registerCesiumViewerWebMcp,
+} from 'cesium-mcp-webmcp/viewer'
 
-const bridge = new CesiumBridge(viewer)
 const registration = isWebMcpSupported()
-  ? await registerCesiumWebMcp(bridge, {
+  ? await registerCesiumViewerWebMcp(viewer, {
       toolsets: 'all',
       excludeTools: ['geocode'],
     })
@@ -41,10 +44,10 @@ const registration = isWebMcpSupported()
 registration?.unregister()
 ```
 
-`registerCesiumWebMcp()` registers the 15-tool `core` selection by default. Use `toolsets: 'all'` for all 61 browser-safe tools, or select only what the page needs:
+`registerCesiumViewerWebMcp()` registers the 15-tool `core` selection by default. Use `toolsets: 'all'` for all 61 browser-safe tools, or select only what the page needs:
 
 ```ts
-await registerCesiumWebMcp(bridge, {
+await registerCesiumViewerWebMcp(viewer, {
   toolsets: ['view', 'entity', 'layer'],
 })
 ```
@@ -56,17 +59,14 @@ The 12 available toolsets are `view`, `entity`, `layer`, `camera`, `entity-ext`,
 The bridge directly executes 60 of the 61 browser-safe contracts. `geocode` needs an application-provided handler because it calls an external service:
 
 ```ts
-const executor = {
-  execute(command) {
-    if (command.action === 'geocode') {
-      return yourGeocoder(command.params)
-    }
-
-    return bridge.execute(command)
+await registerCesiumViewerWebMcp(viewer, {
+  toolsets: 'all',
+  bridgeOptions: {
+    executors: {
+      geocode: params => yourGeocoder(params),
+    },
   },
-}
-
-await registerCesiumWebMcp(executor, { toolsets: 'all' })
+})
 ```
 
 `setIonToken` is intentionally not exposed as a page tool. Cesium ion tokens and model-provider API keys remain application-owned secrets. Do not place private keys in tool schemas, tool results, or browser storage.
@@ -94,7 +94,7 @@ WebMCP is not available in every browser. Keep the application usable without it
 
 ```ts
 if (isWebMcpSupported()) {
-  const registration = await registerCesiumWebMcp(bridge)
+  const registration = await registerCesiumViewerWebMcp(viewer)
   // Store registration and unregister it during teardown.
 }
 ```
@@ -108,7 +108,7 @@ useEffect(() => {
   if (!viewer || !isWebMcpSupported()) return
 
   const controller = new AbortController()
-  void registerCesiumWebMcp(new CesiumBridge(viewer), {
+  void registerCesiumViewerWebMcp(viewer, {
     toolsets: 'all',
     signal: controller.signal,
   }).catch(error => {

--- a/docs/guide/webmcp.md
+++ b/docs/guide/webmcp.md
@@ -27,17 +27,18 @@ Register the tools after creating your Cesium viewer:
 
 ```ts
 import { CesiumBridge } from 'cesium-mcp-bridge'
-import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import { isWebMcpSupported, registerCesiumWebMcp } from 'cesium-mcp-webmcp'
 
 const bridge = new CesiumBridge(viewer)
-
-const registration = await registerCesiumWebMcp(bridge, {
-  toolsets: 'all',
-  excludeTools: ['geocode'],
-})
+const registration = isWebMcpSupported()
+  ? await registerCesiumWebMcp(bridge, {
+      toolsets: 'all',
+      excludeTools: ['geocode'],
+    })
+  : undefined
 
 // Call this when the page or component is unmounted.
-registration.unregister()
+registration?.unregister()
 ```
 
 `registerCesiumWebMcp()` registers the 15-tool `core` selection by default. Use `toolsets: 'all'` for all 61 browser-safe tools, or select only what the page needs:
@@ -92,13 +93,33 @@ For an HTTPS production origin during the trial period, register that exact orig
 WebMCP is not available in every browser. Keep the application usable without it and treat registration as an enhancement:
 
 ```ts
-if ('modelContext' in document) {
+if (isWebMcpSupported()) {
   const registration = await registerCesiumWebMcp(bridge)
   // Store registration and unregister it during teardown.
 }
 ```
 
 The package targets the native `document.modelContext` API and does not install a polyfill.
+
+In React StrictMode, pass a component-owned abort signal so cleanup immediately unregisters completed tools and stops an in-progress registration batch before a replacement mount registers the same names:
+
+```ts
+useEffect(() => {
+  if (!viewer || !isWebMcpSupported()) return
+
+  const controller = new AbortController()
+  void registerCesiumWebMcp(new CesiumBridge(viewer), {
+    toolsets: 'all',
+    signal: controller.signal,
+  }).catch(error => {
+    if (!controller.signal.aborted) console.error(error)
+  })
+
+  return () => controller.abort()
+}, [viewer])
+```
+
+Use `buildCesiumWebMcpTools()` when you need to inspect the final tool payloads without registering them, or when the host wants to call `document.modelContext.registerTool()` itself with additional options.
 
 ## What this package does not include
 

--- a/docs/guide/which-mode.md
+++ b/docs/guide/which-mode.md
@@ -26,6 +26,7 @@ What are you trying to do?
 |---|---|---|---|---|
 | **Agent runs in** | Compatible browser | Web application | Your web application | Desktop client or workflow platform |
 | **MCP service required** | No | No | No | Yes |
+| **Default package** | `cesium-mcp-webmcp` | None | `cesium-mcp-bridge` | `cesium-mcp-runtime` |
 | **Model required by package** | No | Demo provides one | Yes, application-owned | MCP client-owned |
 | **Tool surface** | 15 core or 61 browser-safe tools | Auto-routed bundles up to 20, or all 61 + 61 WebMCP tools | Application-selected | Runtime toolsets |
 | **Best for** | Agent-ready websites | Evaluation and demonstrations | Product AI assistants | MCP ecosystem integration |
@@ -58,11 +59,11 @@ Choose this when you need full control over prompts, model selection, authentica
 ## Path 4: MCP runtime
 
 ```bash
-npx cesium-mcp-runtime
-npx cesium-mcp-runtime --transport http --port 3211
+npx -y cesium-mcp-runtime
+npx -y cesium-mcp-runtime --transport http --port 3211
 ```
 
-Choose this for Claude Desktop, Cursor, VS Code, Dify, n8n, or any external MCP client. This path runs a Node.js MCP service and connects to the browser bridge over WebSocket.
+Choose this for Claude Desktop, Cursor, VS Code, Dify, n8n, or any external MCP client. The one Runtime package includes the MCP service, browser Bridge bundle, session routing, and built-in Viewer. Install `cesium-mcp-bridge` separately only for a custom CesiumJS page.
 
 ## Still unsure?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,16 +27,16 @@ features:
     details: Expose page-local tools directly to compatible browsers, or connect MCP clients through the stable SDK v2 runtime with support for MCP 2025-11-25 and 2026-07-28.
   - icon:
       src: /icons/packages.svg
-    title: Composable Packages, One Ecosystem
-    details: Shared contracts, a pure Cesium executor, separate protocol adapters, and IDE tooling — install only the layers you need.
+    title: One Package per Default Path
+    details: Install `cesium-mcp-runtime` for standard MCP or `cesium-mcp-webmcp` for page-native WebMCP. Low-level packages remain available for custom applications.
   - icon:
       src: /icons/realtime.svg
-    title: Real-Time WebSocket Pipeline
-    details: Sub-second command execution. Tool call flows from AI agent through the runtime to the browser bridge, and results return instantly.
+    title: Protocol-Neutral Execution
+    details: Browser Agent, WebMCP, function calling, and MCP Runtime all reach the same command layer; WebSocket is used only for external MCP-to-Viewer sessions.
   - icon:
       src: /icons/terminal.svg
     title: Zero Configuration
-    details: 'One command to start: `npx cesium-mcp-runtime`. Add the bridge to your CesiumJS app. Connect your AI agent. That is it.'
+    details: 'One command to start: `npx -y cesium-mcp-runtime`. The browser Bridge and built-in Viewer are already included.'
   - icon:
       src: /icons/version.svg
     title: Version-Locked to CesiumJS
@@ -51,7 +51,7 @@ features:
 
 ## Architecture
 
-The diagram below shows the MCP runtime path. WebMCP is a separate browser-native adapter that connects a compatible browser agent directly to the same bridge, without the Node.js runtime or WebSocket transport. [Compare the integration modes](/guide/which-mode).
+The diagram below shows the MCP runtime path. The default Runtime package already serves the Bridge and built-in Viewer; the separate Bridge SDK is only needed for a custom page. WebMCP is a browser-native adapter that connects a compatible browser agent directly to the same command layer, without the Node.js runtime or WebSocket transport. [Compare the integration modes](/guide/which-mode).
 
 <div class="architecture-diagram">
   <div class="arch-node agent">
@@ -146,7 +146,7 @@ The diagram below shows the MCP runtime path. WebMCP is a separate browser-nativ
 
 **2.** `cesium-mcp-runtime` receives the call via stdio and forwards it as a WebSocket command.
 
-**3.** `cesium-mcp-bridge` executes the command on the CesiumJS Viewer in the browser.
+**3.** The packaged `cesium-mcp-bridge` executes the command on the built-in Viewer or a custom CesiumJS page.
 
 **4.** Results flow back through the same pipeline to the AI agent.
 
@@ -158,8 +158,8 @@ The diagram below shows the MCP runtime path. WebMCP is a separate browser-nativ
 |---------|-------------|---------|
 | [`cesium-mcp-contracts`](https://www.npmjs.com/package/cesium-mcp-contracts) | Transport-neutral tool contracts and JSON Schemas | [![npm](https://img.shields.io/npm/v/cesium-mcp-contracts?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-contracts) |
 | [`cesium-mcp-bridge`](https://www.npmjs.com/package/cesium-mcp-bridge) | Browser SDK — embed in your CesiumJS application | [![npm](https://img.shields.io/npm/v/cesium-mcp-bridge?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-bridge) |
-| [`cesium-mcp-webmcp`](https://www.npmjs.com/package/cesium-mcp-webmcp) | Native browser WebMCP adapter | [![npm](https://img.shields.io/npm/v/cesium-mcp-webmcp?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-webmcp) |
-| [`cesium-mcp-runtime`](https://www.npmjs.com/package/cesium-mcp-runtime) | MCP Server — 62 command tools (12 toolsets) and 2 resources for AI agents | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-runtime) |
+| [`cesium-mcp-webmcp`](https://www.npmjs.com/package/cesium-mcp-webmcp) | One-package Viewer integration and native browser WebMCP adapter | [![npm](https://img.shields.io/npm/v/cesium-mcp-webmcp?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-webmcp) |
+| [`cesium-mcp-runtime`](https://www.npmjs.com/package/cesium-mcp-runtime) | One-package MCP Server, built-in Viewer, 62 command tools and 2 resources | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-runtime) |
 | [`cesium-mcp-dev`](https://www.npmjs.com/package/cesium-mcp-dev) | IDE MCP Server — Cesium API docs and code generation | [![npm](https://img.shields.io/npm/v/cesium-mcp-dev?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-dev) |
 
 </div>

--- a/docs/zh-CN/api/dev.md
+++ b/docs/zh-CN/api/dev.md
@@ -10,7 +10,7 @@
 ## 安装与运行
 
 ```bash
-npx cesium-mcp-dev
+npx -y cesium-mcp-dev
 ```
 
 ## IDE 配置

--- a/docs/zh-CN/api/runtime.md
+++ b/docs/zh-CN/api/runtime.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime)](https://www.npmjs.com/package/cesium-mcp-runtime)
 
 ::: tip 发布通道
-- 稳定版：`npx cesium-mcp-runtime` → npm `latest`
+- 稳定版：`npx -y cesium-mcp-runtime` → npm `latest`
 
 稳定版同时支持 MCP `2025-11-25` 和 `2026-07-28`，使用稳定版 TypeScript
 SDK v2，并通过官方 `server-stateless` 一致性场景（28/28）。
@@ -14,8 +14,10 @@ SDK v2，并通过官方 `server-stateless` 一致性场景（28/28）。
 ## 安装与运行
 
 ```bash
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 ```
+
+打开 `http://localhost:9100/` 即可使用包内 Viewer，默认路径无需单独安装 Bridge。
 
 或全局安装：
 
@@ -76,6 +78,8 @@ cesium-mcp-runtime
 工具按 **12 个工具集** 组织。默认启用 4 个核心工具集（30 个工具）。设置 `CESIUM_TOOLSETS=all` 启用全部，或由 AI 在运行时动态发现和激活。共享标题、行为标注、多语言描述、默认值、输入校验、对外发布的输出 Schema 和结构化结果统一来自 `cesium-mcp-contracts` 中的标准 JSON Schema；旧客户端仍可读取文本 `content`。
 
 Runtime npm 产物会包含由 `/bridge.js` 提供的浏览器 Bridge bundle，内置 Viewer 不再依赖 unpkg 回退；CesiumJS 资源仍从 Cesium 官方 CDN 加载。
+
+因此默认 MCP 路径只需要 `cesium-mcp-runtime`。单独安装 `cesium-mcp-bridge` 只用于自定义 CesiumJS 页面，不是内置 Viewer 用户的前提。
 
 ### 工具集
 

--- a/docs/zh-CN/guide/faq.md
+++ b/docs/zh-CN/guide/faq.md
@@ -7,10 +7,10 @@
 **表现**：浏览器控制台显示 `WebSocket connection to 'ws://localhost:9100' failed`。
 
 **解决方案**：
-1. 确认 `cesium-mcp-runtime` 正在运行：`npx cesium-mcp-runtime`
+1. 确认 `cesium-mcp-runtime` 正在运行：`npx -y cesium-mcp-runtime`
 2. 检查端口 — 如果 9100 端口被占用，设置自定义端口：
    ```bash
-   CESIUM_WS_PORT=9200 npx cesium-mcp-runtime
+   CESIUM_WS_PORT=9200 npx -y cesium-mcp-runtime
    ```
    Runtime 将自动在新端口上监听。
 3. 如果使用 HTTPS，浏览器会阻止混合内容（需要使用 wss://）。可使用反向代理或隧道（如 ngrok）。
@@ -30,8 +30,8 @@
 
 Runtime 找不到已连接的浏览器会话。
 
-1. 在浏览器中打开你的 CesiumJS 应用
-2. 检查 Bridge 初始化代码是否在运行（浏览器控制台中查找 `[CesiumBridge] connected`）
+1. 打开内置 Viewer：`http://localhost:9100/?session=default`，或打开自定义 CesiumJS 页面
+2. 自定义页面需检查 Runtime WebSocket 连接是否已经初始化
 3. 如果使用多个标签页，为每个标签页设置不同的 `sessionId`
 
 ### 只有部分工具可用
@@ -39,7 +39,7 @@ Runtime 找不到已连接的浏览器会话。
 默认只启用核心工具集。要启用全部 62 个命令工具：
 
 ```bash
-CESIUM_TOOLSETS=all npx cesium-mcp-runtime
+CESIUM_TOOLSETS=all npx -y cesium-mcp-runtime
 ```
 
 或使用动态发现 — 让 AI 智能体执行：*"列出可用的工具集"*，然后 *"启用动画工具集"*。
@@ -68,7 +68,7 @@ Bridge 不处理令牌 — 由你的 CesiumJS 应用自行管理。
 设置 `CESIUM_WS_PORT` 环境变量：
 
 ```bash
-CESIUM_WS_PORT=9200 npx cesium-mcp-runtime
+CESIUM_WS_PORT=9200 npx -y cesium-mcp-runtime
 ```
 
 ### 能否使用远程/云端模式？
@@ -76,7 +76,7 @@ CESIUM_WS_PORT=9200 npx cesium-mcp-runtime
 可以。Runtime 支持 Streamable HTTP 模式进行远程访问：
 
 ```bash
-npx cesium-mcp-runtime --mode http --port 3000
+npx -y cesium-mcp-runtime --transport http --port 3000
 ```
 
 也可以使用托管端点 `https://mcp.gpb.cc`。

--- a/docs/zh-CN/guide/getting-started.md
+++ b/docs/zh-CN/guide/getting-started.md
@@ -4,56 +4,44 @@
 
 ## 前置条件
 
-- **Node.js** 22 或更高版本
-- 一个 **CesiumJS** 应用（或使用我们提供的最小示例）
+- **Node.js** 20 或更高版本
 - 一个 **兼容 MCP 的 AI 客户端**（Claude Desktop、VS Code Copilot、Cursor 等）
+- 独立的 CesiumJS 应用不是必需项；Runtime 已提供可直接使用的 Viewer
 
-## 安装
+## 一包快速开始
 
 ::: tip MCP SDK v2 已稳定
 npm `latest` 稳定版通过同一个 stdio/HTTP 入口同时支持现有 MCP
 `2025-11-25` 客户端和新的 `2026-07-28` 协议。
 
 ```bash
-npm install cesium-mcp-bridge
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 ```
 :::
 
-### 1. 在 CesiumJS 应用中添加 Bridge
+普通 MCP 用户只需要 `cesium-mcp-runtime` 一个包。它已经包含 MCP Server、WebSocket 会话路由、浏览器 Bridge bundle，以及位于 `http://localhost:9100/` 的内置 Cesium Viewer。
 
-```bash
-npm install cesium-mcp-bridge
-```
-
-创建 Cesium Viewer 后初始化 Bridge：
-
-```js
-import { CesiumBridge } from 'cesium-mcp-bridge'
-
-const viewer = new Cesium.Viewer('cesiumContainer')
-const bridge = new CesiumBridge(viewer)
-```
-
-### 2. 启动 MCP Runtime
+### 手动启动
 
 **stdio 模式**（适用于 Claude Desktop、VS Code、Cursor）：
 
 ```bash
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 ```
 
 **HTTP 模式**（适用于 Dify、n8n 等 HTTP 平台）：
 
 ```bash
-npx cesium-mcp-runtime --transport http --port 3211
+npx -y cesium-mcp-runtime --transport http --port 3211
 ```
 
 运行后会启动一个 Node.js 进程，它会：
 - 在所选传输方式（stdio 或 HTTP）上提供 MCP 工具
-- 在 9100 端口开启 **WebSocket 服务器**（与浏览器 Bridge 通信）
+- 在 9100 端口开启 Viewer 会话所需的 **WebSocket 服务器**
+- 在 `http://localhost:9100/` 提供内置 Viewer
+- 通过 `/bridge.js` 提供包内自带的浏览器 Bridge
 
-### 3. 配置 AI 智能体
+## 配置 AI 智能体
 
 #### Claude Desktop
 
@@ -105,7 +93,7 @@ npx cesium-mcp-runtime --transport http --port 3211
 首先以 HTTP 模式启动 Runtime：
 
 ```bash
-npx cesium-mcp-runtime --transport http --port 3211
+npx -y cesium-mcp-runtime --transport http --port 3211
 ```
 
 然后在 Dify 中添加 MCP 工具节点，配置如下：
@@ -123,20 +111,37 @@ npx cesium-mcp-runtime --transport http --port 3211
 > Docker 部署的 Dify 需将 `localhost` 替换为 `host.docker.internal`。
 > 完整指南：[examples/dify-integration/](https://github.com/gaopengbin/cesium-mcp/tree/main/examples/dify-integration)
 
-### 4. 试一试
+## 试一试
 
-在浏览器中打开你的 CesiumJS 应用，然后对 AI 智能体说：
+在浏览器中打开 `http://localhost:9100/`，然后对 AI 智能体说：
 
 > "飞到埃菲尔铁塔"
 
 智能体会调用 `flyTo` 工具，指令通过 Runtime 路由到 Bridge，你的地球将自动飞行到巴黎。
+
+## 自定义 CesiumJS 应用（可选）
+
+只有当你希望 MCP 命令控制自己应用中的 Viewer，而不是内置 Viewer 时，才需要单独安装 `cesium-mcp-bridge`：
+
+```bash
+npm install cesium-mcp-bridge
+```
+
+```js
+import { CesiumBridge } from 'cesium-mcp-bridge'
+
+const viewer = new Cesium.Viewer('cesiumContainer')
+const bridge = new CesiumBridge(viewer)
+```
+
+自定义页面还需要把 Bridge 连接到 Runtime WebSocket。完整实现请参考[最小自定义页面示例](https://github.com/gaopengbin/cesium-mcp/tree/main/examples/minimal)。这是应用开发路径，不是普通 MCP 用户的安装前提。
 
 ## 仅 IDE 模式 (cesium-mcp-dev)
 
 如果你只需要 AI 辅助编写 CesiumJS 代码（不需要实时地球），可以安装 dev 服务器：
 
 ```bash
-npx cesium-mcp-dev
+npx -y cesium-mcp-dev
 ```
 
 它提供：

--- a/docs/zh-CN/guide/webmcp.md
+++ b/docs/zh-CN/guide/webmcp.md
@@ -20,18 +20,21 @@ HTTPS 在线演示还为明确批准的 HTTP 测试数据配置了一个保持�
 ## 接入已有 Cesium 应用
 
 ```bash
-npm install cesium cesium-mcp-bridge cesium-mcp-webmcp
+npm install cesium-mcp-webmcp
 ```
+
+宿主应用已经拥有 `cesium` 和 Viewer。Bridge 与共享契约会作为依赖自动安装，因此已有 CesiumJS 应用只需增加一个包。
 
 创建 Cesium Viewer 后注册工具：
 
 ```ts
-import { CesiumBridge } from 'cesium-mcp-bridge'
-import { isWebMcpSupported, registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import {
+  isWebMcpSupported,
+  registerCesiumViewerWebMcp,
+} from 'cesium-mcp-webmcp/viewer'
 
-const bridge = new CesiumBridge(viewer)
 const registration = isWebMcpSupported()
-  ? await registerCesiumWebMcp(bridge, {
+  ? await registerCesiumViewerWebMcp(viewer, {
       toolsets: 'all',
       excludeTools: ['geocode'],
     })
@@ -41,10 +44,10 @@ const registration = isWebMcpSupported()
 registration?.unregister()
 ```
 
-`registerCesiumWebMcp()` 默认注册包含 15 个工具的 `core` 选择。使用 `toolsets: 'all'` 可注册全部 61 个浏览器安全工具，也可以只选择页面需要的工具集：
+`registerCesiumViewerWebMcp()` 默认注册包含 15 个工具的 `core` 选择。使用 `toolsets: 'all'` 可注册全部 61 个浏览器安全工具，也可以只选择页面需要的工具集：
 
 ```ts
-await registerCesiumWebMcp(bridge, {
+await registerCesiumViewerWebMcp(viewer, {
   toolsets: ['view', 'entity', 'layer'],
 })
 ```
@@ -56,17 +59,14 @@ await registerCesiumWebMcp(bridge, {
 Bridge 可以直接执行 61 个浏览器安全契约中的 60 个。`geocode` 会访问外部服务，因此需要应用提供处理函数：
 
 ```ts
-const executor = {
-  execute(command) {
-    if (command.action === 'geocode') {
-      return yourGeocoder(command.params)
-    }
-
-    return bridge.execute(command)
+await registerCesiumViewerWebMcp(viewer, {
+  toolsets: 'all',
+  bridgeOptions: {
+    executors: {
+      geocode: params => yourGeocoder(params),
+    },
   },
-}
-
-await registerCesiumWebMcp(executor, { toolsets: 'all' })
+})
 ```
 
 `setIonToken` 有意不作为页面工具暴露。Cesium ion token 和模型服务 API key 都应由应用管理。不要把私钥放入工具 schema、工具结果或浏览器存储中。
@@ -94,7 +94,7 @@ Origin Trial 期间，如果要部署到 HTTPS 生产环境，需要为最终使
 
 ```ts
 if (isWebMcpSupported()) {
-  const registration = await registerCesiumWebMcp(bridge)
+  const registration = await registerCesiumViewerWebMcp(viewer)
   // 保存 registration，并在页面销毁时取消注册。
 }
 ```
@@ -108,7 +108,7 @@ useEffect(() => {
   if (!viewer || !isWebMcpSupported()) return
 
   const controller = new AbortController()
-  void registerCesiumWebMcp(new CesiumBridge(viewer), {
+  void registerCesiumViewerWebMcp(viewer, {
     toolsets: 'all',
     signal: controller.signal,
   }).catch(error => {

--- a/docs/zh-CN/guide/webmcp.md
+++ b/docs/zh-CN/guide/webmcp.md
@@ -27,17 +27,18 @@ npm install cesium cesium-mcp-bridge cesium-mcp-webmcp
 
 ```ts
 import { CesiumBridge } from 'cesium-mcp-bridge'
-import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import { isWebMcpSupported, registerCesiumWebMcp } from 'cesium-mcp-webmcp'
 
 const bridge = new CesiumBridge(viewer)
-
-const registration = await registerCesiumWebMcp(bridge, {
-  toolsets: 'all',
-  excludeTools: ['geocode'],
-})
+const registration = isWebMcpSupported()
+  ? await registerCesiumWebMcp(bridge, {
+      toolsets: 'all',
+      excludeTools: ['geocode'],
+    })
+  : undefined
 
 // 页面或组件卸载时调用。
-registration.unregister()
+registration?.unregister()
 ```
 
 `registerCesiumWebMcp()` 默认注册包含 15 个工具的 `core` 选择。使用 `toolsets: 'all'` 可注册全部 61 个浏览器安全工具，也可以只选择页面需要的工具集：
@@ -92,13 +93,33 @@ Origin Trial 期间，如果要部署到 HTTPS 生产环境，需要为最终使
 并非所有浏览器都支持 WebMCP。应用应在没有 WebMCP 时仍能正常使用，把工具注册作为渐进增强：
 
 ```ts
-if ('modelContext' in document) {
+if (isWebMcpSupported()) {
   const registration = await registerCesiumWebMcp(bridge)
   // 保存 registration，并在页面销毁时取消注册。
 }
 ```
 
 该包只面向原生 `document.modelContext` API，不会安装 polyfill。
+
+在 React StrictMode 中，应从组件生命周期传入独立的取消信号。组件清理时，它会立即注销已经注册的工具，并阻止尚未完成的批量注册继续占用同名工具：
+
+```ts
+useEffect(() => {
+  if (!viewer || !isWebMcpSupported()) return
+
+  const controller = new AbortController()
+  void registerCesiumWebMcp(new CesiumBridge(viewer), {
+    toolsets: 'all',
+    signal: controller.signal,
+  }).catch(error => {
+    if (!controller.signal.aborted) console.error(error)
+  })
+
+  return () => controller.abort()
+}, [viewer])
+```
+
+如果只想检查最终生成的工具对象而不立即注册，或者应用需要自行调用 `document.modelContext.registerTool()` 并传入额外选项，可以使用 `buildCesiumWebMcpTools()`。
 
 ## 这个包不包含什么
 

--- a/docs/zh-CN/guide/which-mode.md
+++ b/docs/zh-CN/guide/which-mode.md
@@ -26,6 +26,7 @@ cesium-mcp 提供 **四种接入路径**，它们共享同一套 Cesium 命令�
 |---|---|---|---|---|
 | **智能体运行位置** | 兼容浏览器 | Web 应用 | 你的 Web 应用 | 桌面客户端或工作流平台 |
 | **是否需要 MCP 服务** | 否 | 否 | 否 | 是 |
+| **默认安装包** | `cesium-mcp-webmcp` | 无 | `cesium-mcp-bridge` | `cesium-mcp-runtime` |
 | **包是否要求模型** | 否 | 演示站提供 | 是，由应用管理 | 由 MCP 客户端管理 |
 | **工具范围** | 15 个核心或 61 个浏览器安全工具 | 自动调度至多 20 个，也可选择全部 61 个 + 61 个 WebMCP 工具 | 应用自行选择 | Runtime 工具集 |
 | **最适合** | 面向智能体的网站 | 体验和演示 | 产品内 AI 助手 | 接入 MCP 生态 |
@@ -58,11 +59,11 @@ WebMCP 不提供 AI 模型或聊天界面。接入步骤见 [WebMCP 浏览器接
 ## 路径 4：MCP runtime
 
 ```bash
-npx cesium-mcp-runtime
-npx cesium-mcp-runtime --transport http --port 3211
+npx -y cesium-mcp-runtime
+npx -y cesium-mcp-runtime --transport http --port 3211
 ```
 
-适合 Claude Desktop、Cursor、VS Code、Dify、n8n 或其他外部 MCP 客户端。这条路径会运行 Node.js MCP 服务，并通过 WebSocket 连接浏览器 Bridge。
+适合 Claude Desktop、Cursor、VS Code、Dify、n8n 或其他外部 MCP 客户端。一个 Runtime 包已经包含 MCP 服务、浏览器 Bridge bundle、会话路由和内置 Viewer。只有接入自定义 CesiumJS 页面时，才需要单独安装 `cesium-mcp-bridge`。
 
 ## 还在犹豫？
 

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -27,16 +27,16 @@ features:
     details: 可直接向兼容浏览器暴露页面工具，也可通过稳定版 SDK v2 Runtime 连接 MCP 客户端，并同时支持 MCP 2025-11-25 与 2026-07-28。
   - icon:
       src: /icons/packages.svg
-    title: 可组合的包，一个生态
-    details: 共享契约、纯 Cesium 执行核心、独立协议适配层与 IDE 工具 — 只安装需要的层。
+    title: 默认路径只装一个包
+    details: 标准 MCP 安装 `cesium-mcp-runtime`，页面原生 WebMCP 安装 `cesium-mcp-webmcp`；自定义应用仍可使用低层包。
   - icon:
       src: /icons/realtime.svg
-    title: 实时 WebSocket 管线
-    details: 亚秒级命令执行。工具调用从 AI 智能体经由 Runtime 到达浏览器 Bridge，结果即时返回。
+    title: 协议无关的执行层
+    details: 浏览器 Agent、WebMCP、Function Calling 与 MCP Runtime 共用同一命令层；只有外部 MCP 到 Viewer 的会话使用 WebSocket。
   - icon:
       src: /icons/terminal.svg
     title: 零配置启动
-    details: '一条命令即可启动：`npx cesium-mcp-runtime`。在 CesiumJS 应用中添加 Bridge。连接 AI 智能体。'
+    details: '一条命令即可启动：`npx -y cesium-mcp-runtime`。浏览器 Bridge 和内置 Viewer 已经包含在包内。'
   - icon:
       src: /icons/version.svg
     title: 版本锁定 CesiumJS
@@ -51,7 +51,7 @@ features:
 
 ## 架构
 
-下图展示 MCP runtime 接入路径。WebMCP 是独立的浏览器原生适配层，兼容的浏览器智能体可以直接连接同一个 Bridge，不需要 Node.js runtime 或 WebSocket 传输层。[查看四种接入模式](/zh-CN/guide/which-mode)。
+下图展示 MCP runtime 接入路径。默认 Runtime 包已经提供 Bridge 和内置 Viewer；只有自定义页面才需要单独使用 Bridge SDK。WebMCP 是浏览器原生适配层，兼容的浏览器智能体可以直接连接同一个命令层，不需要 Node.js runtime 或 WebSocket 传输层。[查看四种接入模式](/zh-CN/guide/which-mode)。
 
 <div class="architecture-diagram">
   <div class="arch-node agent">
@@ -146,7 +146,7 @@ features:
 
 **2.** `cesium-mcp-runtime` 通过 stdio 接收调用，转发为 WebSocket 命令。
 
-**3.** `cesium-mcp-bridge` 在浏览器中的 CesiumJS Viewer 上执行命令。
+**3.** 包内的 `cesium-mcp-bridge` 在内置 Viewer 或自定义 CesiumJS 页面中执行命令。
 
 **4.** 结果通过同一管线返回给 AI 智能体。
 
@@ -158,8 +158,8 @@ features:
 |------|------|------|
 | [`cesium-mcp-contracts`](https://www.npmjs.com/package/cesium-mcp-contracts) | 与传输无关的工具契约与 JSON Schema | [![npm](https://img.shields.io/npm/v/cesium-mcp-contracts?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-contracts) |
 | [`cesium-mcp-bridge`](https://www.npmjs.com/package/cesium-mcp-bridge) | 浏览器 SDK — 嵌入你的 CesiumJS 应用 | [![npm](https://img.shields.io/npm/v/cesium-mcp-bridge?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-bridge) |
-| [`cesium-mcp-webmcp`](https://www.npmjs.com/package/cesium-mcp-webmcp) | 原生浏览器 WebMCP 适配层 | [![npm](https://img.shields.io/npm/v/cesium-mcp-webmcp?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-webmcp) |
-| [`cesium-mcp-runtime`](https://www.npmjs.com/package/cesium-mcp-runtime) | MCP 服务器 — 62 个命令工具（12 个工具集）和 2 个资源 | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-runtime) |
+| [`cesium-mcp-webmcp`](https://www.npmjs.com/package/cesium-mcp-webmcp) | 一包完成 Viewer 接入，并提供浏览器原生 WebMCP 适配层 | [![npm](https://img.shields.io/npm/v/cesium-mcp-webmcp?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-webmcp) |
+| [`cesium-mcp-runtime`](https://www.npmjs.com/package/cesium-mcp-runtime) | 一包提供 MCP Server、内置 Viewer、62 个命令工具和 2 个资源 | [![npm](https://img.shields.io/npm/v/cesium-mcp-runtime?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-runtime) |
 | [`cesium-mcp-dev`](https://www.npmjs.com/package/cesium-mcp-dev) | IDE MCP 服务器 — Cesium API 文档与代码生成 | [![npm](https://img.shields.io/npm/v/cesium-mcp-dev?color=1a1a2e&labelColor=e2e8f0)](https://www.npmjs.com/package/cesium-mcp-dev) |
 
 </div>

--- a/examples/dify-integration/README.md
+++ b/examples/dify-integration/README.md
@@ -5,7 +5,7 @@
 ## 环境要求
 
 - Docker Desktop（用于运行 Dify）
-- Node.js 18+
+- Node.js 20+
 - 支持 Function Calling 的 LLM（如 Ollama qwen3、OpenAI GPT-4 等）
 
 ## 架构概览
@@ -25,23 +25,19 @@
 ### 1. 启动 Cesium MCP Runtime
 
 ```bash
-# 安装
-npm install -g cesium-mcp-runtime
-
-# 启动 HTTP 模式
-npx cesium-mcp-runtime --transport http --port 3211
+# 一个包直接启动 HTTP 模式
+npx -y cesium-mcp-runtime --transport http --port 3211
 
 # 输出示例：
 # [cesium-mcp-runtime] HTTP + WebSocket server on http://localhost:9100
-# [cesium-mcp-runtime] MCP Server running (Streamable HTTP), 58 tools available
+# [cesium-mcp-runtime] MCP Server running (Streamable HTTP), 62 tools available
 # [cesium-mcp-runtime] MCP endpoint: http://localhost:3211/mcp
 ```
 
 ### 2. 打开 CesiumJS Demo 页面
 
-1. 在浏览器中打开：`http://localhost:9100/demo/index.html`
-2. 修改 WebSocket URL 为：`ws://localhost:9100?session=default`
-3. 点击「连接」，确认显示"已连接"
+1. 在浏览器中打开内置 Viewer：`http://localhost:9100/?session=default`
+2. 确认页面显示 Runtime 会话已连接
 
 > **重要**：session 必须设为 `default`，这是 MCP 工具的默认会话标识。
 
@@ -139,7 +135,7 @@ Agent 会解析为两个工具调用：
 | `addGeoJsonLayer` | 加载 GeoJSON |
 | `setBasemap` | 切换底图 |
 | `screenshot` | 截取地图图片 |
-| ... | 共 58 个工具 |
+| ... | 共 62 个工具 |
 
 完整工具列表参见 [API 文档](../../docs/api/runtime.md)
 

--- a/examples/emergency-response/README.md
+++ b/examples/emergency-response/README.md
@@ -19,13 +19,13 @@
 cd packages/cesium-mcp-runtime
 npx tsx src/index.ts
 
-# 方式 B: 全局安装
-npx cesium-mcp-runtime
+# 方式 B: 直接使用 npm 稳定版（一包包含内置 Viewer）
+npx -y cesium-mcp-runtime
 ```
 
 ### 2. 打开地图页面
 
-- 使用 `packages/cesium-mcp-runtime/demo/index.html`
+- 普通体验直接打开 `http://localhost:9100/?session=default`
 - 或运行你自己的 Cesium 应用（需集成 cesium-mcp-bridge）
 - 确保 WebSocket 连接状态为 **已连接**（绿点）
 
@@ -37,7 +37,7 @@ VS Code `.vscode/mcp.json`:
   "servers": {
     "cesium-mcp": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"],
+      "args": ["-y", "cesium-mcp-runtime"],
       "type": "stdio",
       "env": { "CESIUM_TOOLSETS": "all" }
     }

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -1,6 +1,6 @@
 # Cesium MCP 极简接入示例
 
-一个最小化的完整示例，展示如何用 cesium-mcp-bridge + cesium-mcp-runtime 让 AI Agent 操控浏览器中的 Cesium 3D 地图。
+一个面向应用开发者的自定义页面示例，展示如何把 cesium-mcp-bridge 接到 cesium-mcp-runtime。普通 MCP 用户无需使用本示例，直接运行 Runtime 自带的 Viewer 即可。
 
 ## 文件结构
 
@@ -12,11 +12,10 @@ examples/minimal/
 
 ## 快速体验
 
-### 步骤 1: 启动 Runtime
+### 步骤 1: 启动 Runtime（一包即可）
 
 ```bash
-cd packages/cesium-mcp-runtime
-npx tsx src/index.ts
+npx -y cesium-mcp-runtime
 # 监听 9100 端口 (HTTP + WebSocket + MCP stdio)
 ```
 
@@ -40,7 +39,7 @@ npx serve examples/minimal -l 3000
   "mcpServers": {
     "cesium": {
       "command": "npx",
-      "args": ["tsx", "<项目路径>/packages/cesium-mcp-runtime/src/index.ts"]
+      "args": ["-y", "cesium-mcp-runtime"]
     }
   }
 }

--- a/examples/webmcp-integration/README.md
+++ b/examples/webmcp-integration/README.md
@@ -13,7 +13,12 @@ Enable Chrome's WebMCP testing flag for localhost, then open the page and inspec
 
 ## Integration boundary
 
+An existing CesiumJS application installs only `cesium-mcp-webmcp`. The package's `/viewer` entry includes the Bridge dependency, while the root entry keeps the low-level adapter available for custom executors.
+
 ```ts
+import { CesiumBridge } from 'cesium-mcp-webmcp/viewer'
+import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+
 const bridge = new CesiumBridge(viewer)
 const executor = {
   execute(command) {
@@ -27,7 +32,7 @@ const registration = await registerCesiumWebMcp(executor, {
 })
 ```
 
-- `cesium-mcp-bridge` executes Cesium commands.
+- `cesium-mcp-webmcp/viewer` provides the packaged Cesium Bridge.
 - `cesium-mcp-webmcp` registers transport-neutral contracts on `document.modelContext`.
 - The application owns credentials and optional services such as geocoding.
 - Call `registration.unregister()` when the page or component is unmounted.

--- a/examples/webmcp-integration/README.zh-CN.md
+++ b/examples/webmcp-integration/README.zh-CN.md
@@ -13,7 +13,12 @@ npm run dev
 
 ## 接入边界
 
+已有 CesiumJS 应用只需安装 `cesium-mcp-webmcp`。包内的 `/viewer` 入口会自动带上 Bridge 依赖，根入口继续为自定义 Executor 提供低层适配器。
+
 ```ts
+import { CesiumBridge } from 'cesium-mcp-webmcp/viewer'
+import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+
 const bridge = new CesiumBridge(viewer)
 const executor = {
   execute(command) {
@@ -27,8 +32,8 @@ const registration = await registerCesiumWebMcp(executor, {
 })
 ```
 
-- `cesium-mcp-bridge` 只执行 Cesium 命令。
-- `cesium-mcp-webmcp` 只把共享契约注册到 `document.modelContext`。
+- `cesium-mcp-webmcp/viewer` 提供已打包的 Cesium Bridge。
+- `cesium-mcp-webmcp` 把共享契约注册到 `document.modelContext`。
 - 凭据和地理编码等可选服务由应用自己管理。
 - 页面或组件卸载时调用 `registration.unregister()`。
 

--- a/examples/webmcp-integration/package.json
+++ b/examples/webmcp-integration/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "cesium": "~1.143.0",
-    "cesium-mcp-bridge": "^1.143.4",
     "cesium-mcp-webmcp": "^0.2.0"
   },
   "devDependencies": {

--- a/examples/webmcp-integration/src/main.ts
+++ b/examples/webmcp-integration/src/main.ts
@@ -6,7 +6,7 @@ import {
   OpenStreetMapImageryProvider,
   Viewer,
 } from 'cesium'
-import { CesiumBridge } from 'cesium-mcp-bridge'
+import { CesiumBridge } from 'cesium-mcp-webmcp/viewer'
 import {
   registerCesiumWebMcp,
 } from 'cesium-mcp-webmcp'

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
       "version": "0.1.2",
       "dependencies": {
         "cesium": "~1.143.0",
-        "cesium-mcp-bridge": "^1.143.4",
         "cesium-mcp-webmcp": "^0.2.0"
       },
       "devDependencies": {
@@ -11675,14 +11674,18 @@
       }
     },
     "packages/cesium-mcp-webmcp": {
-      "version": "0.2.2",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
-        "cesium-mcp-contracts": "^0.4.0"
+        "cesium-mcp-bridge": "^1.145.1",
+        "cesium-mcp-contracts": "^0.6.0"
       },
       "devDependencies": {
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "cesium": "~1.143.0"
       }
     }
   }

--- a/packages/cesium-mcp-dev/README.md
+++ b/packages/cesium-mcp-dev/README.md
@@ -21,7 +21,7 @@ IDE AI Assistant <--MCP stdio--> cesium-mcp-dev --> API docs, code snippets, Ent
 ## Install & Run
 
 ```bash
-npx cesium-mcp-dev
+npx -y cesium-mcp-dev
 ```
 
 ## IDE Configuration

--- a/packages/cesium-mcp-dev/README.zh-CN.md
+++ b/packages/cesium-mcp-dev/README.zh-CN.md
@@ -21,7 +21,7 @@ IDE AI 助手 <--MCP stdio--> cesium-mcp-dev --> API 文档、代码片段、Ent
 ## 安装与运行
 
 ```bash
-npx cesium-mcp-dev
+npx -y cesium-mcp-dev
 ```
 
 ## IDE 配置

--- a/packages/cesium-mcp-runtime/README.md
+++ b/packages/cesium-mcp-runtime/README.md
@@ -25,6 +25,8 @@ The runtime acts as a bridge between MCP-compatible AI clients (Claude Desktop, 
 
 The npm package ships its browser Bridge bundle locally. The built-in Viewer at `http://localhost:9100/` therefore does not depend on an unpkg fallback; CesiumJS itself is still loaded from the official Cesium CDN.
 
+For ordinary MCP users this is a one-package setup: run `cesium-mcp-runtime` and use the built-in Viewer. Install `cesium-mcp-bridge` separately only when developing a custom CesiumJS page.
+
 Two transport modes are supported:
 
 | Transport | Use Case | Protocol |
@@ -36,12 +38,14 @@ Two transport modes are supported:
 
 ```bash
 # Stable channel (stdio mode, default)
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 
 # Or install globally
 npm install -g cesium-mcp-runtime
 cesium-mcp-runtime
 ```
+
+Then open `http://localhost:9100/` to use the built-in Viewer. No separate Bridge installation is required for this default path.
 
 ### Streamable HTTP Mode
 
@@ -49,7 +53,7 @@ For remote/cloud MCP clients like Dify:
 
 ```bash
 # Start in HTTP transport mode
-npx cesium-mcp-runtime --transport http --port 3000
+npx -y cesium-mcp-runtime --transport http --port 3000
 
 # MCP endpoint: POST http://localhost:3000/mcp
 ```
@@ -57,7 +61,7 @@ npx cesium-mcp-runtime --transport http --port 3000
 Environment variable alternative:
 
 ```bash
-MCP_TRANSPORT=http MCP_HTTP_PORT=3000 npx cesium-mcp-runtime
+MCP_TRANSPORT=http MCP_HTTP_PORT=3000 npx -y cesium-mcp-runtime
 ```
 
 In HTTP mode, all 62 Cesium command tools are enabled by default (no dynamic toolset discovery needed).
@@ -71,7 +75,7 @@ In HTTP mode, all 62 Cesium command tools are enabled by default (no dynamic too
   "mcpServers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"],
+      "args": ["-y", "cesium-mcp-runtime"],
       "env": {
         "CESIUM_WS_PORT": "9100",
         "DEFAULT_SESSION_ID": "default"
@@ -90,7 +94,7 @@ In `.vscode/mcp.json`:
   "servers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"],
+      "args": ["-y", "cesium-mcp-runtime"],
       "env": {
         "DEFAULT_SESSION_ID": "default"
       }
@@ -108,7 +112,7 @@ In `.cursor/mcp.json`:
   "mcpServers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"]
+      "args": ["-y", "cesium-mcp-runtime"]
     }
   }
 }
@@ -142,7 +146,7 @@ Tools are organized into **12 toolsets**. By default, 4 core toolsets are enable
   "mcpServers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"],
+      "args": ["-y", "cesium-mcp-runtime"],
       "env": {
         "CESIUM_TOOLSETS": "all"
       }

--- a/packages/cesium-mcp-runtime/README.zh-CN.md
+++ b/packages/cesium-mcp-runtime/README.zh-CN.md
@@ -24,6 +24,8 @@ AI 智能体 <--MCP HTTP---> cesium-mcp-runtime <--WebSocket--> 浏览器 (cesiu
 
 npm 包会直接携带浏览器 Bridge bundle，因此 `http://localhost:9100/` 内置 Viewer 不再依赖 unpkg 回退；CesiumJS 本身仍从 Cesium 官方 CDN 加载。
 
+普通 MCP 用户只需使用这一个包：运行 `cesium-mcp-runtime` 并打开内置 Viewer。只有开发自定义 CesiumJS 页面时，才需要单独安装 `cesium-mcp-bridge`。
+
 支持两种传输模式：
 
 | 传输方式 | 适用场景 | 协议 |
@@ -35,12 +37,14 @@ npm 包会直接携带浏览器 Bridge bundle，因此 `http://localhost:9100/` 
 
 ```bash
 # 稳定通道（stdio 模式，默认）
-npx cesium-mcp-runtime
+npx -y cesium-mcp-runtime
 
 # 也可以全局安装
 npm install -g cesium-mcp-runtime
 cesium-mcp-runtime
 ```
+
+然后打开 `http://localhost:9100/` 使用内置 Viewer。默认路径不需要另外安装 Bridge。
 
 ### Streamable HTTP 模式
 
@@ -48,7 +52,7 @@ cesium-mcp-runtime
 
 ```bash
 # 以 HTTP 传输模式启动
-npx cesium-mcp-runtime --transport http --port 3000
+npx -y cesium-mcp-runtime --transport http --port 3000
 
 # MCP 端点：POST http://localhost:3000/mcp
 ```
@@ -56,7 +60,7 @@ npx cesium-mcp-runtime --transport http --port 3000
 也可通过环境变量配置：
 
 ```bash
-MCP_TRANSPORT=http MCP_HTTP_PORT=3000 npx cesium-mcp-runtime
+MCP_TRANSPORT=http MCP_HTTP_PORT=3000 npx -y cesium-mcp-runtime
 ```
 
 HTTP 模式下默认启用全部 62 个 Cesium 命令工具（无需动态工具集发现）。
@@ -70,7 +74,7 @@ HTTP 模式下默认启用全部 62 个 Cesium 命令工具（无需动态工具
   "mcpServers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"],
+      "args": ["-y", "cesium-mcp-runtime"],
       "env": {
         "CESIUM_WS_PORT": "9100",
         "DEFAULT_SESSION_ID": "default"
@@ -89,7 +93,7 @@ HTTP 模式下默认启用全部 62 个 Cesium 命令工具（无需动态工具
   "servers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"],
+      "args": ["-y", "cesium-mcp-runtime"],
       "env": {
         "DEFAULT_SESSION_ID": "default"
       }
@@ -107,7 +111,7 @@ HTTP 模式下默认启用全部 62 个 Cesium 命令工具（无需动态工具
   "mcpServers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"]
+      "args": ["-y", "cesium-mcp-runtime"]
     }
   }
 }
@@ -141,7 +145,7 @@ HTTP 模式下默认启用全部 62 个 Cesium 命令工具（无需动态工具
   "mcpServers": {
     "cesium": {
       "command": "npx",
-      "args": ["cesium-mcp-runtime"],
+      "args": ["-y", "cesium-mcp-runtime"],
       "env": {
         "CESIUM_TOOLSETS": "all"
       }

--- a/packages/cesium-mcp-webmcp/README.md
+++ b/packages/cesium-mcp-webmcp/README.md
@@ -14,16 +14,18 @@ npm install cesium cesium-mcp-bridge cesium-mcp-webmcp
 
 ```typescript
 import { CesiumBridge } from 'cesium-mcp-bridge'
-import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import { isWebMcpSupported, registerCesiumWebMcp } from 'cesium-mcp-webmcp'
 
 const bridge = new CesiumBridge(viewer)
-const registration = await registerCesiumWebMcp(bridge, {
-  toolsets: 'all',
-  excludeTools: ['geocode'],
-})
+const registration = isWebMcpSupported()
+  ? await registerCesiumWebMcp(bridge, {
+      toolsets: 'all',
+      excludeTools: ['geocode'],
+    })
+  : undefined
 
 // Remove only the tools owned by this registration.
-registration.unregister()
+registration?.unregister()
 ```
 
 `registerCesiumWebMcp()` defaults to the 15-contract `core` selection. Pass `toolsets: 'all'` for all 61 browser-safe tools, one toolset name, or an array such as `['view', 'entity', 'layer']`. To register a custom contract subset, pass `tools`, or call the lower-level `registerWebMcpTools()` function.
@@ -39,6 +41,36 @@ await registerCesiumWebMcp(bridge, {
 An explicit `tools` array takes precedence over `toolsets`, and `excludeTools` removes individual contracts afterward. The Bridge directly executes 60 of the 61 browser-safe contracts. `geocode` needs an application-provided executor handler, as shown by the browser-agent example. `setIonToken` is never part of the browser-safe collection because credentials should remain application-owned.
 
 The executor is structural: any object implementing `execute({ action, params })` can be used. A backend `cesium-mcp-runtime` process is not required.
+
+Use `buildCesiumWebMcpTools()` when an application needs to inspect the final WebMCP payloads or register them manually with additional browser-specific options:
+
+```typescript
+import { buildCesiumWebMcpTools } from 'cesium-mcp-webmcp'
+
+const tools = buildCesiumWebMcpTools(bridge, {
+  toolsets: ['view', 'entity'],
+})
+```
+
+## React StrictMode
+
+Pass an external abort signal from the component lifecycle. Cleanup aborts the active batch immediately, unregisters tools that were already added, and prevents a superseded StrictMode mount from continuing with the remaining names:
+
+```typescript
+useEffect(() => {
+  if (!viewer || !isWebMcpSupported()) return
+
+  const controller = new AbortController()
+  void registerCesiumWebMcp(new CesiumBridge(viewer), {
+    toolsets: 'all',
+    signal: controller.signal,
+  }).catch(error => {
+    if (!controller.signal.aborted) console.error(error)
+  })
+
+  return () => controller.abort()
+}, [viewer])
+```
 
 ## Browser bundle
 

--- a/packages/cesium-mcp-webmcp/README.md
+++ b/packages/cesium-mcp-webmcp/README.md
@@ -1,24 +1,27 @@
 # cesium-mcp-webmcp
 
-Native WebMCP registration for Cesium browser tools. This package owns only the `document.modelContext` adapter and uses transport-neutral contracts from `cesium-mcp-contracts`.
+Native WebMCP registration for Cesium browser tools. The `/viewer` entry provides a one-package CesiumJS integration, while the package root remains a lightweight `document.modelContext` adapter for custom executors.
 
-It does not include CesiumJS, the Cesium execution bridge, a backend MCP server, or a WebMCP polyfill.
+It does not bundle CesiumJS, a backend MCP server, or a WebMCP polyfill.
 
 ## Install
 
 ```bash
-npm install cesium cesium-mcp-bridge cesium-mcp-webmcp
+npm install cesium-mcp-webmcp
 ```
 
-## Usage
+`cesium` remains a peer dependency because the host application owns its Viewer. `cesium-mcp-bridge` and the shared contracts are installed automatically.
+
+## One-package Viewer API
 
 ```typescript
-import { CesiumBridge } from 'cesium-mcp-bridge'
-import { isWebMcpSupported, registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import {
+  isWebMcpSupported,
+  registerCesiumViewerWebMcp,
+} from 'cesium-mcp-webmcp/viewer'
 
-const bridge = new CesiumBridge(viewer)
 const registration = isWebMcpSupported()
-  ? await registerCesiumWebMcp(bridge, {
+  ? await registerCesiumViewerWebMcp(viewer, {
       toolsets: 'all',
       excludeTools: ['geocode'],
     })
@@ -28,25 +31,29 @@ const registration = isWebMcpSupported()
 registration?.unregister()
 ```
 
-`registerCesiumWebMcp()` defaults to the 15-contract `core` selection. Pass `toolsets: 'all'` for all 61 browser-safe tools, one toolset name, or an array such as `['view', 'entity', 'layer']`. To register a custom contract subset, pass `tools`, or call the lower-level `registerWebMcpTools()` function.
+The returned object includes `registration.bridge` for direct commands. `unregister()` removes the page tools and disposes the package-owned Bridge while leaving the application-owned Viewer intact.
+
+`registerCesiumViewerWebMcp()` defaults to the 15-contract `core` selection. Pass `toolsets: 'all'` for all 61 browser-safe tools, one toolset name, or an array such as `['view', 'entity', 'layer']`. To register a custom contract subset, pass `tools`.
 
 ```typescript
-import { registerCesiumWebMcp } from 'cesium-mcp-webmcp'
+import { registerCesiumViewerWebMcp } from 'cesium-mcp-webmcp/viewer'
 
-await registerCesiumWebMcp(bridge, {
+await registerCesiumViewerWebMcp(viewer, {
   toolsets: ['view', 'entity', 'layer'],
 })
 ```
 
 An explicit `tools` array takes precedence over `toolsets`, and `excludeTools` removes individual contracts afterward. The Bridge directly executes 60 of the 61 browser-safe contracts. `geocode` needs an application-provided executor handler, as shown by the browser-agent example. `setIonToken` is never part of the browser-safe collection because credentials should remain application-owned.
 
-The executor is structural: any object implementing `execute({ action, params })` can be used. A backend `cesium-mcp-runtime` process is not required.
+The lower-level adapter remains available from the package root for applications that already own an executor. Any object implementing `execute({ action, params })` can be passed to `registerCesiumWebMcp()`. A backend `cesium-mcp-runtime` process is not required.
 
 Use `buildCesiumWebMcpTools()` when an application needs to inspect the final WebMCP payloads or register them manually with additional browser-specific options:
 
 ```typescript
 import { buildCesiumWebMcpTools } from 'cesium-mcp-webmcp'
+import { CesiumBridge } from 'cesium-mcp-webmcp/viewer'
 
+const bridge = new CesiumBridge(viewer)
 const tools = buildCesiumWebMcpTools(bridge, {
   toolsets: ['view', 'entity'],
 })
@@ -61,7 +68,7 @@ useEffect(() => {
   if (!viewer || !isWebMcpSupported()) return
 
   const controller = new AbortController()
-  void registerCesiumWebMcp(new CesiumBridge(viewer), {
+  void registerCesiumViewerWebMcp(viewer, {
     toolsets: 'all',
     signal: controller.signal,
   }).catch(error => {

--- a/packages/cesium-mcp-webmcp/package.json
+++ b/packages/cesium-mcp-webmcp/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./viewer": {
+      "types": "./dist/viewer.d.ts",
+      "import": "./dist/viewer.js",
+      "require": "./dist/viewer.cjs"
+    },
     "./browser": "./dist/cesium-mcp-webmcp.browser.global.js"
   },
   "files": [
@@ -25,7 +30,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "cesium-mcp-bridge": "^1.145.1",
     "cesium-mcp-contracts": "^0.6.0"
+  },
+  "peerDependencies": {
+    "cesium": "~1.143.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/cesium-mcp-webmcp/src/index.test.ts
+++ b/packages/cesium-mcp-webmcp/src/index.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  buildCesiumWebMcpTools,
   cesiumBrowserToolContracts,
   cesiumCoreToolContracts,
+  isWebMcpSupported,
   registerCesiumWebMcp,
   registerWebMcpTools,
 } from './index.js'
@@ -18,6 +20,31 @@ function createModelContext(): WebMcpModelContext & { registered: Array<{ tool: 
 }
 
 describe('registerCesiumWebMcp', () => {
+  it('detects native WebMCP support without throwing', () => {
+    expect(isWebMcpSupported({ modelContext: createModelContext() })).toBe(true)
+    expect(isWebMcpSupported({})).toBe(false)
+    expect(isWebMcpSupported()).toBe(false)
+  })
+
+  it('builds inspectable tool payloads without registering them', async () => {
+    const execute = vi.fn().mockResolvedValue({ success: true })
+    const tools = buildCesiumWebMcpTools({ execute }, {
+      toolsets: ['camera'],
+    })
+
+    expect(tools.map(tool => tool.name)).toEqual([
+      'lookAtTransform',
+      'startOrbit',
+      'stopOrbit',
+      'setCameraOptions',
+    ])
+    await tools[0]!.execute({ longitude: 116.4, latitude: 39.9 })
+    expect(execute).toHaveBeenCalledWith({
+      action: 'lookAtTransform',
+      params: { longitude: 116.4, latitude: 39.9 },
+    })
+  })
+
   it('registers the shared core contracts and forwards execution', async () => {
     const modelContext = createModelContext()
     const execute = vi.fn().mockResolvedValue({ success: true })
@@ -52,6 +79,41 @@ describe('registerCesiumWebMcp', () => {
     expect(new Set(signals).size).toBe(1)
     registration.unregister()
     expect(signals[0].aborted).toBe(true)
+  })
+
+  it('does not start registration when the caller signal is already aborted', async () => {
+    const modelContext = createModelContext()
+    const controller = new AbortController()
+    controller.abort()
+
+    const registration = await registerCesiumWebMcp({ execute: vi.fn() }, {
+      modelContext,
+      signal: controller.signal,
+    })
+
+    expect(registration.registered).toEqual([])
+    expect(registration.signal.aborted).toBe(true)
+    expect(modelContext.registered).toHaveLength(0)
+  })
+
+  it('stops a registration batch as soon as the caller signal aborts', async () => {
+    const controller = new AbortController()
+    const registered: string[] = []
+    const modelContext: WebMcpModelContext = {
+      async registerTool(tool) {
+        registered.push(tool.name)
+        controller.abort()
+      },
+    }
+
+    const registration = await registerCesiumWebMcp({ execute: vi.fn() }, {
+      modelContext,
+      signal: controller.signal,
+    })
+
+    expect(registered).toEqual(['flyTo'])
+    expect(registration.registered).toEqual(['flyTo'])
+    expect(registration.signal.aborted).toBe(true)
   })
 
   it('registers all browser-safe contracts or selected toolsets on demand', async () => {

--- a/packages/cesium-mcp-webmcp/src/index.ts
+++ b/packages/cesium-mcp-webmcp/src/index.ts
@@ -71,10 +71,21 @@ export interface RegisterCesiumWebMcpOptions extends RegisterWebMcpToolsOptions 
   excludeTools?: readonly string[]
 }
 
+export type BuildCesiumWebMcpToolsOptions = Pick<
+  RegisterCesiumWebMcpOptions,
+  'tools' | 'toolsets' | 'excludeTools'
+>
+
 export interface WebMcpRegistration {
   registered: string[]
   signal: AbortSignal
   unregister(): void
+}
+
+export function isWebMcpSupported(documentRef?: WebMcpDocument): boolean {
+  const resolvedDocument = documentRef
+    ?? (typeof document === 'undefined' ? undefined : document as unknown as WebMcpDocument)
+  return Boolean(resolvedDocument?.modelContext)
 }
 
 function resolveModelContext(options: RegisterWebMcpToolsOptions): WebMcpModelContext {
@@ -96,12 +107,37 @@ function assertUniqueToolNames(tools: readonly CesiumToolContract[]): void {
   }
 }
 
+export function buildWebMcpTools(
+  executor: CesiumWebMcpExecutor,
+  tools: readonly CesiumToolContract[],
+): WebMcpRegisteredTool[] {
+  assertUniqueToolNames(tools)
+  return tools.map(tool => {
+    const annotations = tool.annotations
+      ? {
+          ...(annotationValue(tool.annotations.readOnlyHint, 'readOnlyHint')),
+          ...(annotationValue(tool.annotations.untrustedContentHint, 'untrustedContentHint')),
+        }
+      : undefined
+
+    return {
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      outputSchema: tool.outputSchema,
+      annotations: annotations && Object.keys(annotations).length > 0 ? annotations : undefined,
+      execute: input => executor.execute({ action: tool.name, params: input }),
+    }
+  })
+}
+
 export async function registerWebMcpTools(
   executor: CesiumWebMcpExecutor,
   tools: readonly CesiumToolContract[],
   options: RegisterWebMcpToolsOptions = {},
 ): Promise<WebMcpRegistration> {
-  assertUniqueToolNames(tools)
+  const webMcpTools = buildWebMcpTools(executor, tools)
   const modelContext = resolveModelContext(options)
   const controller = new AbortController()
   const unregister = () => controller.abort()
@@ -113,23 +149,9 @@ export async function registerWebMcpTools(
 
   const registered: string[] = []
   try {
-    for (const tool of tools) {
-      const annotations = tool.annotations
-        ? {
-            ...(annotationValue(tool.annotations.readOnlyHint, 'readOnlyHint')),
-            ...(annotationValue(tool.annotations.untrustedContentHint, 'untrustedContentHint')),
-          }
-        : undefined
-
-      await modelContext.registerTool({
-        name: tool.name,
-        title: tool.title,
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-        outputSchema: tool.outputSchema,
-        annotations: annotations && Object.keys(annotations).length > 0 ? annotations : undefined,
-        execute: input => executor.execute({ action: tool.name, params: input }),
-      }, {
+    for (const tool of webMcpTools) {
+      if (controller.signal.aborted) break
+      await modelContext.registerTool(tool, {
         signal: controller.signal,
         ...(options.exposedTo ? { exposedTo: options.exposedTo } : {}),
       })
@@ -143,23 +165,41 @@ export async function registerWebMcpTools(
   return { registered, signal: controller.signal, unregister }
 }
 
+export function buildCesiumWebMcpTools(
+  executor: CesiumWebMcpExecutor,
+  options: BuildCesiumWebMcpToolsOptions = {},
+): WebMcpRegisteredTool[] {
+  return buildWebMcpTools(executor, selectWebMcpContracts(options))
+}
+
 export function registerCesiumWebMcp(
   executor: CesiumWebMcpExecutor,
   options: RegisterCesiumWebMcpOptions = {},
 ): Promise<WebMcpRegistration> {
+  const registrationOptions: RegisterWebMcpToolsOptions = {
+    modelContext: options.modelContext,
+    document: options.document,
+    signal: options.signal,
+    exposedTo: options.exposedTo,
+  }
+  return registerWebMcpTools(
+    executor,
+    selectWebMcpContracts(options),
+    registrationOptions,
+  )
+}
+
+function selectWebMcpContracts(
+  options: BuildCesiumWebMcpToolsOptions,
+): readonly CesiumToolContract[] {
   const {
     tools,
     toolsets = 'core',
     excludeTools = [],
-    ...registrationOptions
   } = options
   const selectedTools = tools ?? selectCesiumToolContracts(toolsets)
   const excludedNames = new Set(excludeTools)
-  return registerWebMcpTools(
-    executor,
-    selectedTools.filter(tool => !excludedNames.has(tool.name)),
-    registrationOptions,
-  )
+  return selectedTools.filter(tool => !excludedNames.has(tool.name))
 }
 
 function annotationValue<K extends 'readOnlyHint' | 'untrustedContentHint'>(

--- a/packages/cesium-mcp-webmcp/src/viewer.test.ts
+++ b/packages/cesium-mcp-webmcp/src/viewer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CesiumBridge,
+  registerCesiumViewerWebMcp,
+} from './viewer.js'
+import type { WebMcpModelContext } from './index.js'
+
+describe('registerCesiumViewerWebMcp', () => {
+  it('creates and owns the Bridge behind a one-package Viewer API', async () => {
+    const registered: string[] = []
+    const modelContext: WebMcpModelContext = {
+      async registerTool(tool) {
+        registered.push(tool.name)
+      },
+    }
+    const viewer = {
+      camera: { cancelFlight: vi.fn() },
+    } as any
+
+    const registration = await registerCesiumViewerWebMcp(viewer, {
+      modelContext,
+      toolsets: ['camera'],
+    })
+
+    expect(registration.bridge).toBeInstanceOf(CesiumBridge)
+    expect(registered).toEqual([
+      'lookAtTransform',
+      'startOrbit',
+      'stopOrbit',
+      'setCameraOptions',
+    ])
+
+    const dispose = vi.spyOn(registration.bridge, 'dispose')
+    registration.unregister()
+    expect(registration.signal.aborted).toBe(true)
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/cesium-mcp-webmcp/src/viewer.ts
+++ b/packages/cesium-mcp-webmcp/src/viewer.ts
@@ -1,0 +1,50 @@
+import { CesiumBridge } from 'cesium-mcp-bridge'
+import type { CesiumBridgeOptions } from 'cesium-mcp-bridge'
+import type { Viewer } from 'cesium'
+import { registerCesiumWebMcp } from './index.js'
+import type {
+  RegisterCesiumWebMcpOptions,
+  WebMcpRegistration,
+} from './index.js'
+
+export { CesiumBridge } from 'cesium-mcp-bridge'
+export type { CesiumBridgeOptions } from 'cesium-mcp-bridge'
+export { isWebMcpSupported } from './index.js'
+
+export interface RegisterCesiumViewerWebMcpOptions extends RegisterCesiumWebMcpOptions {
+  bridgeOptions?: CesiumBridgeOptions
+}
+
+export interface CesiumViewerWebMcpRegistration extends WebMcpRegistration {
+  bridge: CesiumBridge
+}
+
+/**
+ * One-package convenience API for existing CesiumJS applications.
+ * Creates the Bridge, registers WebMCP tools, and owns both lifecycles.
+ */
+export async function registerCesiumViewerWebMcp(
+  viewer: Viewer,
+  options: RegisterCesiumViewerWebMcpOptions = {},
+): Promise<CesiumViewerWebMcpRegistration> {
+  const { bridgeOptions, ...registrationOptions } = options
+  const bridge = new CesiumBridge(viewer, bridgeOptions)
+  const disposeBridge = () => bridge.dispose()
+
+  if (options.signal?.aborted) disposeBridge()
+  else options.signal?.addEventListener('abort', disposeBridge, { once: true })
+
+  try {
+    const registration = await registerCesiumWebMcp(bridge, registrationOptions)
+    const unregister = () => {
+      options.signal?.removeEventListener('abort', disposeBridge)
+      registration.unregister()
+      disposeBridge()
+    }
+    return { ...registration, bridge, unregister }
+  } catch (error) {
+    options.signal?.removeEventListener('abort', disposeBridge)
+    disposeBridge()
+    throw error
+  }
+}

--- a/packages/cesium-mcp-webmcp/tsup.config.ts
+++ b/packages/cesium-mcp-webmcp/tsup.config.ts
@@ -2,12 +2,12 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig([
   {
-    entry: ['src/index.ts'],
+    entry: ['src/index.ts', 'src/viewer.ts'],
     format: ['esm', 'cjs'],
     dts: true,
     splitting: false,
     clean: true,
-    external: ['cesium-mcp-contracts'],
+    external: ['cesium', 'cesium-mcp-bridge', 'cesium-mcp-contracts'],
     treeshake: true,
   },
   {


### PR DESCRIPTION
## Summary

- add `cesium-mcp-webmcp/viewer`, a one-package entry that creates and owns the Bridge for an existing CesiumJS Viewer
- make `cesium-mcp-bridge` and shared contracts automatic WebMCP dependencies, so application developers install only `cesium-mcp-webmcp`
- keep the lightweight root adapter and Cesium-free browser IIFE unchanged for custom executors and early page-tool registration
- add safe WebMCP capability detection, inspectable tool payload builders, and StrictMode-safe cancellation
- standardize ordinary MCP setup on the single `cesium-mcp-runtime` package and its built-in Viewer
- reserve standalone `cesium-mcp-bridge` installation for explicitly documented custom-page and function-calling integrations
- update English and Chinese root READMEs, package READMEs, website home pages, Getting Started, mode comparison, API pages, FAQ, and examples
- clarify the independent, protocol-agnostic project positioning across Browser Agent, WebMCP, function calling, and standard MCP

## Why

Default users should not need to understand or install internal packages. Existing CesiumJS applications now add WebMCP with one package and one `/viewer` import. Standard MCP users already receive the Bridge bundle and built-in Viewer from `cesium-mcp-runtime`; the documentation now reflects that actual shipped behavior.

WebMCP registration can also overlap during asynchronous component lifecycles, especially under React StrictMode. A stale registration batch must stop before a replacement mount registers the same tool names.

## Validation

- fresh temporary project: installed `cesium-mcp-webmcp` only and verified automatic Bridge/Contracts dependencies plus `/viewer` imports
- `npm ci --ignore-scripts`
- `npm test` — 28 files, 354 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run build -w packages/cesium-mcp-webmcp`
- `npm run build -w examples/webmcp-integration`
- `npm run docs:build`
- `npm pack --dry-run -w packages/cesium-mcp-webmcp`
- residual documentation scan for old install commands, tool counts, demo routes, and CLI flags
- `git diff --check`
