### PR TITLE
Fix strict MCP client validation for array schemas

### DIFF
--- a/.changeset/calm-maps-validate.md
+++ b/.changeset/calm-maps-validate.md
@@ -1,0 +1,5 @@
+---
+'cesium-mcp-contracts': patch
+---
+
+Add `items` to every advertised input array schema for VS Code and other strict MCP clients while preserving tuple constraints through `prefixItems`.

--- a/packages/cesium-mcp-contracts/src/extended-tools.ts
+++ b/packages/cesium-mcp-contracts/src/extended-tools.ts
@@ -14,6 +14,7 @@ const durationSchema: JsonSchema = { type: 'number', minimum: 0, maximum: 86400 
 const positionTupleSchema: JsonSchema = {
   type: 'array',
   prefixItems: [longitudeSchema, latitudeSchema, heightSchema],
+  items: numberSchema,
   minItems: 2,
   maxItems: 3,
 }
@@ -122,6 +123,7 @@ export const cesiumExtendedToolContracts: readonly CesiumToolContract[] = [
     bbox: {
       type: 'array',
       prefixItems: [longitudeSchema, latitudeSchema, longitudeSchema, latitudeSchema],
+      items: numberSchema,
       minItems: 4,
       maxItems: 4,
     },
@@ -179,6 +181,7 @@ export const cesiumExtendedToolContracts: readonly CesiumToolContract[] = [
     bbox: {
       type: 'array',
       prefixItems: [longitudeSchema, latitudeSchema, longitudeSchema, latitudeSchema],
+      items: numberSchema,
       minItems: 4,
       maxItems: 4,
     },
@@ -446,7 +449,11 @@ export const cesiumExtendedToolContracts: readonly CesiumToolContract[] = [
   tool('loadCzml', 'Load CZML data from inline packets or a URL.', {
     id: idSchema,
     name: { ...stringSchema, maxLength: 200 },
-    data: { type: 'array', maxItems: 10000 },
+    data: {
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+      maxItems: 10000,
+    },
     url: urlSchema,
     sourceUri: urlSchema,
     clampToGround: booleanSchema,

--- a/packages/cesium-mcp-contracts/src/tools.test.ts
+++ b/packages/cesium-mcp-contracts/src/tools.test.ts
@@ -31,6 +31,23 @@ describe('cesiumCoreToolContracts', () => {
     ])
   })
 
+  it('publishes items for every input array for strict MCP clients', () => {
+    const missing: string[] = []
+
+    const visit = (value: unknown, path: string): void => {
+      if (!value || typeof value !== 'object') return
+      const schema = value as Record<string, unknown>
+      if (schema.type === 'array' && !('items' in schema)) missing.push(path)
+      for (const [key, child] of Object.entries(schema)) visit(child, `${path}.${key}`)
+    }
+
+    for (const tool of cesiumBrowserToolContracts) {
+      visit(tool.inputSchema, tool.name)
+    }
+
+    expect(missing).toEqual([])
+  })
+
   it('publishes one canonical shared inventory and toolset definition', () => {
     expect(cesiumSharedToolNames).toEqual(cesiumBrowserToolContracts.map(tool => tool.name))
     expect(new Set(cesiumSharedToolNames).size).toBe(cesiumSharedToolNames.length)

--- a/packages/cesium-mcp-contracts/src/tools.ts
+++ b/packages/cesium-mcp-contracts/src/tools.ts
@@ -41,6 +41,7 @@ const positionSchema: JsonSchema = {
       description: 'Optional height in meters',
     },
   ],
+  items: { type: 'number' },
   minItems: 2,
   maxItems: 3,
   description: 'Coordinate tuple [longitude, latitude, optional height]',


### PR DESCRIPTION
## Summary

- add `items` to every advertised input array schema while preserving coordinate tuple constraints through `prefixItems`
- describe inline CZML arrays as object packets
- add a recursive regression test covering all 61 browser-safe tool input schemas
- publish a patch changeset for `cesium-mcp-contracts`

## Root cause

VS Code's MCP tool validator rejects any `type: array` schema without an explicit `items` member. Several coordinate tuples used valid modern JSON Schema `prefixItems`, but strict clients rejected the tool catalogue before any model or browser command ran. `measure.positions` was the first reported path, while the same compatibility gap affected 13 nested array locations.

## User impact

Tool discovery no longer fails with `tool parameters array type must have items` for `measure`, polylines, polygons, trajectories, bounding boxes, GeoJSON coordinates, or CZML packets.

Fixes #28.

## Validation

- recursive audit: 13 missing array `items` entries before, 0 after
- `npm test` — 27 files, 350 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run test:contracts`
- `npm run test:conformance:mcp` — 28/28
- `npm run test:e2e:packed` — clean npm pack, real Viewer, `setView -> getView`
- `git diff --check`
