### PR TITLE
Upgrade GitHub Actions runtime dependencies to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out chart data branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: star-history-data
           path: star-history-data


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` from v4/v6 to v7.0.1 across CI, Release, Docs, and Star History
- upgrade `actions/setup-node` from v4 to v7.0.0 across CI, Release, and Docs
- pin every upgraded action to the exact official release commit SHA

## Why

GitHub now warns that the Node 20 runtime used by the older action versions is deprecated and forced onto Node 24. Updating the action implementations removes that infrastructure warning without changing the project's Node 20/22 test matrix.

## Validation

- verified official releases: checkout v7.0.1 and setup-node v7.0.0
- resolved and pinned the official release commit SHAs
- parsed all four workflow YAML files successfully
- confirmed no checkout/setup-node v4 references remain
- `git diff --check`

No application code, package versions, or npm artifacts change.
