### PR TITLE
fix(bridge): omit undefined layer dataRefId from results

### DIFF
--- a/packages/cesium-mcp-bridge/src/commands/layer.test.ts
+++ b/packages/cesium-mcp-bridge/src/commands/layer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const mockCesium = vi.hoisted(() => {
   class MockColor {
@@ -193,6 +193,7 @@ vi.mock('../utils', () => ({
   parseColor: mockCesium.parseColor,
 }))
 
+import { validateCesiumToolOutput } from 'cesium-mcp-contracts'
 import { detectGeometryType, LayerManager } from './layer.js'
 
 function makeViewer() {
@@ -283,6 +284,45 @@ describe('detectGeometryType', () => {
 
   it('should return 未知 for no features property', () => {
     expect(detectGeometryType({})).toBe('未知')
+  })
+})
+
+describe('LayerManager optional dataRefId', () => {
+  beforeEach(() => {
+    mockDsEntities.length = 0
+    vi.stubGlobal('window', { devicePixelRatio: 1 })
+    vi.stubGlobal('document', {
+      createElement: () => ({
+        getContext: () => ({ beginPath: vi.fn(), arc: vi.fn(), fill: vi.fn(), stroke: vi.fn() }),
+      }),
+    })
+  })
+
+  afterEach(() => vi.unstubAllGlobals())
+
+  it.each([undefined, '', 'natural-data'])('returns valid GeoJSON layer info with dataRefId %s', async (dataRefId) => {
+    const mgr = new LayerManager(makeViewer())
+    const info = await mgr.addGeoJsonLayer({
+      id: 'natural_surface',
+      url: 'https://example.com/features.geojson',
+      dataRefId,
+    })
+
+    expect(validateCesiumToolOutput('addGeoJsonLayer', { success: true, data: info }).valid).toBe(true)
+    if (dataRefId === undefined) {
+      expect(info).not.toHaveProperty('dataRefId')
+      expect(mgr.listLayers()[0]).not.toHaveProperty('dataRefId')
+    } else {
+      expect(info.dataRefId).toBe(dataRefId)
+      expect(mgr.listLayers()[0]?.dataRefId).toBe(dataRefId)
+    }
+  })
+
+  it('omits absent dataRefId when listing other layer types', () => {
+    const mgr = new LayerManager(makeViewer())
+    registerLayer(mgr, 'other-layer')
+
+    expect(mgr.listLayers()[0]).not.toHaveProperty('dataRefId')
   })
 })
 

--- a/packages/cesium-mcp-bridge/src/commands/layer.ts
+++ b/packages/cesium-mcp-bridge/src/commands/layer.ts
@@ -197,7 +197,7 @@ export class LayerManager {
       type: geomType,
       visible: true,
       color,
-      dataRefId,
+      ...(dataRefId !== undefined ? { dataRefId } : {}),
     }
     this._cesiumRefs.set(layerId, { dataSource: ds, styleEntities, polygonOutlines })
     this._layers.push(info)
@@ -500,7 +500,14 @@ export class LayerManager {
   }
 
   listLayers(): LayerInfo[] {
-    return this._layers.map(({ id, name, type, visible, color, dataRefId }) => ({ id, name, type, visible, color, dataRefId }))
+    return this._layers.map(({ id, name, type, visible, color, dataRefId }) => ({
+      id,
+      name,
+      type,
+      visible,
+      color,
+      ...(dataRefId !== undefined ? { dataRefId } : {}),
+    }))
   }
 
   getLayerSchema(params: GetLayerSchemaParams): LayerSchemaResult {


### PR DESCRIPTION
## Summary
- Omit optional `dataRefId` from `addGeoJsonLayer` results when undefined, preventing output validation from rejecting otherwise successful layer loads.
- Apply the same omission in `listLayers`, while preserving supplied strings (including empty strings).
- Add four regression cases covering missing and supplied references and listing other layer types.

## Validation
- Reproduced the output validation failure with regression tests before applying the fix.
- All 383 tests pass.
- Typecheck, ESLint, and full build pass.

## Notes
- Generated build artifacts are not included; rebuild the Bridge to deploy the fix.